### PR TITLE
Add cookies support for http API extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,8 @@ Then:
   - /^response status should be (.+)$/
   - /^response should (not )?have an? (.+) cookie$/
   - /^response (.+) cookie should (not )?be secure$/
-  - /^response (.+) cookie should (not )?be http only/
+  - /^response (.+) cookie should (not )?be http only$/
+  - /^response (.+) cookie domain should (not )?be (.+)$/
   - /^(?:I )?should receive a json response (fully )?matching$/
   - /^(?:I )?should receive a collection of ([0-9]+) items?(?: for path )?(.+)?$/
   - /^response should match snapshot (.+)$/

--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ yarn run examples -- --tags @cli
 [npm-url]: https://www.npmjs.com/package/@ekino/veggies
 [travis-image]: https://img.shields.io/travis/ekino/veggies.svg?style=flat-square
 [travis-url]: https://travis-ci.org/ekino/veggies
-[prettier-image]: https://img.shields.io/badge/styled_with-prettier-ff69b4.svg?style=flat-square
+[prettier-image]: https://img.shields.io/badge/styled_with-prettier-44cc11.svg?style=flat-square
 [prettier-url]: https://github.com/prettier/prettier
 [coverage-image]: https://img.shields.io/coveralls/ekino/veggies/master.svg?style=flat-square
 [coverage-url]: https://coveralls.io/github/ekino/veggies?branch=master

--- a/README.md
+++ b/README.md
@@ -391,12 +391,16 @@ httpApi.install({
 Given:
   - /^(?:I )?set request headers$/
   - /^(?:I )?set ([a-zA-Z0-9-]+) request header to (.+)$/
+  - /^(?:I )?clear request headers/
   - /^(?:I )?set request json body$/
   - /^(?:I )?set request json body from (.+)$/
   - /^(?:I )?set request form body$/
   - /^(?:I )?set request form body from (.+)$/
+  - /^(?:I )?clear request body$/
   - /^(?:I )?set request query$/
   - /^(?:I )?pick response json (.+) as (.+)$/
+  - /^(?:I )?enable cookies$/
+  - /^(?:I )?disable cookies$/
 
 When:
   - /^(?:I )?reset http client$/
@@ -405,6 +409,9 @@ When:
 
 Then:
   - /^(?:I )?should receive a ([1-5][0-9][0-9]) HTTP status code$/
+  - /^response should have a (.*) cookie$/
+  - /^response (.*) cookie should (not )?be secure$/
+  - /^response (.*) cookie should (not )?be http only/
   - /^(?:I )?should receive a json response (fully )?matching$/
   - /^(?:I )?should receive a collection of ([0-9]+) items?(?: for path )?(.+)?$/
   - /^response should match snapshot (.+)$/
@@ -509,7 +516,7 @@ yarn run examples -- --tags @cli
 [npm-url]: https://www.npmjs.com/package/@ekino/veggies
 [travis-image]: https://img.shields.io/travis/ekino/veggies.svg?style=flat-square
 [travis-url]: https://travis-ci.org/ekino/veggies
-[prettier-image]: https://img.shields.io/badge/styled_with-prettier-44cc11.svg?style=flat-square
+[prettier-image]: https://img.shields.io/badge/styled_with-prettier-ff69b4.svg?style=flat-square
 [prettier-url]: https://github.com/prettier/prettier
 [coverage-image]: https://img.shields.io/coveralls/ekino/veggies/master.svg?style=flat-square
 [coverage-url]: https://coveralls.io/github/ekino/veggies?branch=master

--- a/README.md
+++ b/README.md
@@ -408,7 +408,8 @@ When:
   - /^(?:I )?dump response body$/
 
 Then:
-  - /^(?:I )?should receive a ([1-5][0-9][0-9]) HTTP status code$/
+  - /^response status code should be ([1-5][0-9][0-9])$/
+  - /^response status should be (.+)$/
   - /^response should have a (.*) cookie$/
   - /^response (.*) cookie should (not )?be secure$/
   - /^response (.*) cookie should (not )?be http only/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It's also the perfect companion for testing CLI applications built with commande
         - [Posting data](#posting-data)
         - [Posting data using fixture file](#posting-data-using-fixture-file)
         - [Using values issued by a previous request](#using-values-issued-by-a-previous-request)
+        - [Using cookies](#using-cookies)
         - [Type system](#type-system)
     - [CLI testing](#cli-testing) 
        - [Running a simple command](#running-a-simple-command-and-checking-its-exit-code)
@@ -109,7 +110,7 @@ Scenario: Creating a resource using json payload
 #### Posting data using fixture file
 
 Putting large data payloads inside your scenarios can reduce legibility,
-to improve this, you can use the [fixtures](#fixtures-extension) to define it.
+to improve this, you can use the [fixtures extension](#fixtures-extension) to define it.
 
 ```yaml
 # /features/user/fixtures/user.yml
@@ -174,6 +175,25 @@ Scenario Outline: Fetching <key> API endpoint from root endpoint
     | feeds_url        |
     | public_gists_url |
 ```
+
+#### Using cookies
+
+Cookies are disabled by default, but you've got the ability to enable/disable the feature using a gherkin `Given` expression.
+Be warned that cookies do not persist across scenarios in order to ensure they're autonomous.
+If you really need to keep a cookie for multiple scenarios, you should consider using a custom step definition
+and/or using the [state extention](#state-extension) to store it.
+
+```gherkin
+Scenario: Enabling cookies
+  Given I enable cookies
+  # …
+  
+Scenario: Disabling cookies
+  Given I disable cookies
+  # …  
+```
+
+See [definitions](#http-api-gherkin-expressions) for all available cookies related gherkin expressions.
 
 #### Type system
 

--- a/README.md
+++ b/README.md
@@ -430,9 +430,9 @@ When:
 Then:
   - /^response status code should be ([1-5][0-9][0-9])$/
   - /^response status should be (.+)$/
-  - /^response should have a (.*) cookie$/
-  - /^response (.*) cookie should (not )?be secure$/
-  - /^response (.*) cookie should (not )?be http only/
+  - /^response should (not )?have an? (.+) cookie$/
+  - /^response (.+) cookie should (not )?be secure$/
+  - /^response (.+) cookie should (not )?be http only/
   - /^(?:I )?should receive a json response (fully )?matching$/
   - /^(?:I )?should receive a collection of ([0-9]+) items?(?: for path )?(.+)?$/
   - /^response should match snapshot (.+)$/

--- a/doc/README.tpl.md
+++ b/doc/README.tpl.md
@@ -16,6 +16,7 @@ It's also the perfect companion for testing CLI applications built with commande
         - [Posting data](#posting-data)
         - [Posting data using fixture file](#posting-data-using-fixture-file)
         - [Using values issued by a previous request](#using-values-issued-by-a-previous-request)
+        - [Using cookies](#using-cookies)
         - [Type system](#type-system)
     - [CLI testing](#cli-testing) 
        - [Running a simple command](#running-a-simple-command-and-checking-its-exit-code)
@@ -109,7 +110,7 @@ Scenario: Creating a resource using json payload
 #### Posting data using fixture file
 
 Putting large data payloads inside your scenarios can reduce legibility,
-to improve this, you can use the [fixtures](#fixtures-extension) to define it.
+to improve this, you can use the [fixtures extension](#fixtures-extension) to define it.
 
 ```yaml
 # /features/user/fixtures/user.yml
@@ -178,6 +179,25 @@ Scenario Outline: Fetching <key> API endpoint from root endpoint
     | public_gists_url |
 ```
 <%={{ }}=%>
+
+#### Using cookies
+
+Cookies are disabled by default, but you've got the ability to enable/disable the feature using a gherkin `Given` expression.
+Be warned that cookies do not persist across scenarios in order to ensure they're autonomous.
+If you really need to keep a cookie for multiple scenarios, you should consider using a custom step definition
+and/or using the [state extention](#state-extension) to store it.
+
+```gherkin
+Scenario: Enabling cookies
+  Given I enable cookies
+  # …
+  
+Scenario: Disabling cookies
+  Given I disable cookies
+  # …  
+```
+
+See [definitions](#http-api-gherkin-expressions) for all available cookies related gherkin expressions.
 
 #### Type system
 

--- a/examples/features/http_api/cookies.feature
+++ b/examples/features/http_api/cookies.feature
@@ -1,27 +1,10 @@
 @http_api @cookies
-Feature: GitHub API
+Feature: Using cookies
 
-#  Scenario: Using GitHub API
-#    Given enable cookies
-#    When I GET https://twitter.com/
-#    Then I should receive a 200 HTTP status code
-#    And response should have a guest_id cookie
-#    And response guest_id cookie should not be secure
-#    And response guest_id cookie should not be http only
-
-  Scenario: test
-    Given I enable cookies
-    And set request headers
-      | Content-Type | application/x-www-form-urlencoded; charset=utf-8 |
-      | Accept       | application/json                                 |
-    And I set request form body
-      | grant_type                | whatever |
-      | google_authorization_code | whatever |
-      | client_id                 | whatever |
-    When I POST http://localhost:8070/api/v1/proxy/auth
-    And I dump response body
-    Given I clear request body
+  Scenario: Twitter home
+    Given enable cookies
+    When I GET https://twitter.com/
     Then response status should be ok
-    When I GET http://localhost:8070/api/v1/proxy/verify
-    And I dump response body
-    Then response status should be ok
+    And response should have a guest_id cookie
+    And response guest_id cookie should not be secure
+    And response guest_id cookie should not be http only

--- a/examples/features/http_api/cookies.feature
+++ b/examples/features/http_api/cookies.feature
@@ -1,0 +1,10 @@
+@http_api @cookies
+Feature: GitHub API
+
+  Scenario: Using GitHub API
+    Given enable cookies
+    When I GET https://twitter.com/
+    Then I should receive a 200 HTTP status code
+    And response should have a guest_id cookie
+    And response guest_id cookie should not be secure
+    And response guest_id cookie should not be http only

--- a/examples/features/http_api/cookies.feature
+++ b/examples/features/http_api/cookies.feature
@@ -21,7 +21,7 @@ Feature: GitHub API
     When I POST http://localhost:8070/api/v1/proxy/auth
     And I dump response body
     Given I clear request body
-    #Then I should receive a 200 HTTP status code
+    Then response status should be ok
     When I GET http://localhost:8070/api/v1/proxy/verify
     And I dump response body
-    Then I should receive a 200 HTTP status code
+    Then response status should be ok

--- a/examples/features/http_api/cookies.feature
+++ b/examples/features/http_api/cookies.feature
@@ -1,10 +1,27 @@
 @http_api @cookies
 Feature: GitHub API
 
-  Scenario: Using GitHub API
-    Given enable cookies
-    When I GET https://twitter.com/
+#  Scenario: Using GitHub API
+#    Given enable cookies
+#    When I GET https://twitter.com/
+#    Then I should receive a 200 HTTP status code
+#    And response should have a guest_id cookie
+#    And response guest_id cookie should not be secure
+#    And response guest_id cookie should not be http only
+
+  Scenario: test
+    Given I enable cookies
+    And set request headers
+      | Content-Type | application/x-www-form-urlencoded; charset=utf-8 |
+      | Accept       | application/json                                 |
+    And I set request form body
+      | grant_type                | ekino                                         |
+      | google_authorization_code | 4/nXXR1hDzzqi7qjOE5qF5YFmibifiQ_IzULvUovajtrY |
+      | client_id                 | 4be37f59-0143-470d-a0fb-514f63da5d70          |
+    When I POST http://localhost:8070/api/v1/proxy/auth
+    And I dump response body
+    Given I clear request body
+    #Then I should receive a 200 HTTP status code
+    When I GET http://localhost:8070/api/v1/proxy/verify
+    And I dump response body
     Then I should receive a 200 HTTP status code
-    And response should have a guest_id cookie
-    And response guest_id cookie should not be secure
-    And response guest_id cookie should not be http only

--- a/examples/features/http_api/cookies.feature
+++ b/examples/features/http_api/cookies.feature
@@ -15,9 +15,9 @@ Feature: GitHub API
       | Content-Type | application/x-www-form-urlencoded; charset=utf-8 |
       | Accept       | application/json                                 |
     And I set request form body
-      | grant_type                | ekino                                         |
-      | google_authorization_code | 4/nXXR1hDzzqi7qjOE5qF5YFmibifiQ_IzULvUovajtrY |
-      | client_id                 | 4be37f59-0143-470d-a0fb-514f63da5d70          |
+      | grant_type                | whatever |
+      | google_authorization_code | whatever |
+      | client_id                 | whatever |
     When I POST http://localhost:8070/api/v1/proxy/auth
     And I dump response body
     Given I clear request body

--- a/examples/features/http_api/fixtures/fixtures.feature
+++ b/examples/features/http_api/fixtures/fixtures.feature
@@ -6,7 +6,7 @@ Feature: Using fixtures with http API extension
     Given I mock http call to forward request body for path /users/yaml
     And set request json body from yaml_00
     When I POST http://fake.io/users/yaml
-    Then I should receive a 200 HTTP status code
+    Then response status code should be 200
     And response should match snapshot yaml_00
 
   @yaml
@@ -14,7 +14,7 @@ Feature: Using fixtures with http API extension
     Given I mock http call to forward request body for path /users/yaml
     And set request form body from yaml_00
     When I POST http://fake.io/users/yaml
-    Then I should receive a 200 HTTP status code
+    Then response status code should be 200
     And response should match url encoded snapshot yaml_00
 
   @yaml
@@ -22,7 +22,7 @@ Feature: Using fixtures with http API extension
     Given I mock http call to forward request body for path /users/yml
     And set request json body from yaml_01
     When I POST http://fake.io/users/yml
-    Then I should receive a 200 HTTP status code
+    Then response status code should be 200
     And response should match snapshot yaml_01
 
   @yaml
@@ -30,7 +30,7 @@ Feature: Using fixtures with http API extension
     Given I mock http call to forward request body for path /users/yml
     And set request form body from yaml_01
     When I POST http://fake.io/users/yml
-    Then I should receive a 200 HTTP status code
+    Then response status code should be 200
     And response should match url encoded snapshot yaml_01
 
   @text
@@ -38,7 +38,7 @@ Feature: Using fixtures with http API extension
     Given I mock http call to forward request body for path /users/txt
     And set request json body from text_00
     When I POST http://fake.io/users/txt
-    Then I should receive a 200 HTTP status code
+    Then response status code should be 200
     And response should match snapshot text_00
 
   @text
@@ -46,7 +46,7 @@ Feature: Using fixtures with http API extension
     Given I mock http call to forward request body for path /users/txt
     And set request form body from text_00
     When I POST http://fake.io/users/txt
-    Then I should receive a 200 HTTP status code
+    Then response status code should be 200
     And response should match snapshot text_00
 
   @js
@@ -54,7 +54,7 @@ Feature: Using fixtures with http API extension
     Given I mock http call to forward request body for path /users/js
     And set request json body from module_00
     When I POST http://fake.io/users/js
-    Then I should receive a 200 HTTP status code
+    Then response status code should be 200
     And response should match snapshot module_00
 
   @js
@@ -62,7 +62,7 @@ Feature: Using fixtures with http API extension
     Given I mock http call to forward request body for path /users/js
     And set request form body from module_00
     When I POST http://fake.io/users/js
-    Then I should receive a 200 HTTP status code
+    Then response status code should be 200
     And response should match url encoded snapshot module_00
 
   @json
@@ -70,7 +70,7 @@ Feature: Using fixtures with http API extension
     Given I mock http call to forward request body for path /users/json
     And set request json body from json_00
     When I POST http://fake.io/users/json
-    Then I should receive a 200 HTTP status code
+    Then response status code should be 200
     And response should match snapshot json_00
 
   @json
@@ -78,5 +78,5 @@ Feature: Using fixtures with http API extension
     Given I mock http call to forward request body for path /users/json
     And set request form body from json_00
     When I POST http://fake.io/users/json
-    Then I should receive a 200 HTTP status code
+    Then response status code should be 200
     And response should match url encoded snapshot json_00

--- a/examples/features/http_api/github.feature
+++ b/examples/features/http_api/github.feature
@@ -4,18 +4,18 @@ Feature: GitHub API
   Scenario: Using GitHub API
     Given I set User-Agent request header to veggies/1.0
     When I GET https://api.github.com/
-    Then I should receive a 200 HTTP status code
+    Then response status code should be 200
     When I pick response json emojis_url as emojisUrl
     And I GET {{emojisUrl}}
-    Then I should receive a 200 HTTP status code
+    Then response status code should be 200
 
   Scenario Outline: Fetching <key> API endpoint from root endpoint
     Given I set User-Agent request header to veggies/1.0
     When I GET https://api.github.com/
-    Then I should receive a 200 HTTP status code
+    Then response status code should be 200
     When I pick response json <key> as <key>
     And I GET {{<key>}}
-    Then I should receive a 200 HTTP status code
+    Then response status code should be 200
 
     Examples:
       | key              |

--- a/src/cast.js
+++ b/src/cast.js
@@ -71,6 +71,7 @@ exports.value = value => {
                 break
 
             case 'string':
+                casted = matchResult[1]
                 break
 
             default:

--- a/src/extensions/cli/definitions.js
+++ b/src/extensions/cli/definitions.js
@@ -24,15 +24,8 @@ module.exports = ({ Given, When, Then }) => {
         this.cli.scheduleKillProcess(delay, signal)
     })
 
-    When(/^(?:I )?run command (.+)$/, function(command, callback) {
-        this.cli
-            .run(command)
-            .then(() => {
-                /* console.log(this.cli.getOutput('stdout'), this.cli.getOutput('stderr')); */ callback()
-            })
-            .catch((...args) => {
-                /* console.log(this.cli.getOutput('stdout'), this.cli.getOutput('stderr')); */ callback(...args)
-            })
+    When(/^(?:I )?run command (.+)$/, function(command) {
+        return this.cli.run(command)
     })
 
     When(/^(?:I )?dump (stderr|stdout)$/, function(type) {

--- a/src/extensions/http_api/client.js
+++ b/src/extensions/http_api/client.js
@@ -87,11 +87,11 @@ exports.setHeader = (key, value) => {
     headers[key] = value
 }
 
-exports.enableCookieJar = () => {
+exports.enableCookies = () => {
     cookieJar = request.jar()
 }
 
-exports.disableCookieJar = () => {
+exports.disableCookies = () => {
     cookieJar = null
 }
 
@@ -100,6 +100,12 @@ exports.setCookie = (key, value) => {
     headers[key] = value
 }
 
+/**
+ * Retrieves a cookie by its key.
+ *
+ * @param {string} key - Cookie key
+ * @return {Object|null} The cookie object if any, or null
+ */
 exports.getCookie = key => {
     if (responseCookies === null) return null
     if (responseCookies[key] === undefined) return null

--- a/src/extensions/http_api/client.js
+++ b/src/extensions/http_api/client.js
@@ -17,8 +17,11 @@ let bodyType = null
 let headers = null
 let query = null
 
+let cookieJar = null
+
 // RESPONSE INFORMATION
 let response = null
+let responseCookies = null
 
 /**
  * Resets the client.
@@ -28,7 +31,11 @@ exports.reset = () => {
     bodyType = null
     headers = null
     query = null
+
+    cookieJar = null
+
     response = null
+    responseCookies = null
 }
 
 /**
@@ -80,6 +87,26 @@ exports.setHeader = (key, value) => {
     headers[key] = value
 }
 
+exports.enableCookieJar = () => {
+    cookieJar = request.jar()
+}
+
+exports.disableCookieJar = () => {
+    cookieJar = null
+}
+
+exports.setCookie = (key, value) => {
+    headers = headers || {}
+    headers[key] = value
+}
+
+exports.getCookie = key => {
+    if (responseCookies === null) return null
+    if (responseCookies[key] === undefined) return null
+
+    return responseCookies[key]
+}
+
 /**
  * Returns the latest collected response.
  */
@@ -102,7 +129,8 @@ exports.makeRequest = (method, path, baseUrl) => {
             uri: path,
             method,
             qs: query || {},
-            headers
+            headers,
+            jar: cookieJar
         }
 
         if (body !== null) {
@@ -125,6 +153,14 @@ exports.makeRequest = (method, path, baseUrl) => {
             }
 
             response = _response
+
+            if (cookieJar !== null) {
+                responseCookies = {}
+                cookieJar.getCookies(`${baseUrl}${path}`).forEach(cookie => {
+                    responseCookies[cookie.key] = cookie
+                })
+            }
+
             resolve()
         })
     })

--- a/src/extensions/http_api/client.js
+++ b/src/extensions/http_api/client.js
@@ -59,6 +59,14 @@ exports.setFormBody = payload => {
 }
 
 /**
+ * Clears current request body
+ */
+exports.clearBody = () => {
+    body = null
+    bodyType = null
+}
+
+/**
  * Sets request query parameters.
  *
  * @param {Object} _query
@@ -87,14 +95,33 @@ exports.setHeader = (key, value) => {
     headers[key] = value
 }
 
+/**
+ * Clears current request headers.
+ */
+exports.clearHeaders = () => {
+    headers = null
+}
+
+/**
+ * Enables cookie jar.
+ */
 exports.enableCookies = () => {
     cookieJar = request.jar()
 }
 
+/**
+ * Disables cookie jar.
+ */
 exports.disableCookies = () => {
     cookieJar = null
 }
 
+/**
+ * Sets a cookie.
+ *
+ * @param {string} key   - Cookie key
+ * @param {string} value - Cookie value
+ */
 exports.setCookie = (key, value) => {
     headers = headers || {}
     headers[key] = value

--- a/src/extensions/http_api/client.js
+++ b/src/extensions/http_api/client.js
@@ -107,6 +107,7 @@ exports.clearHeaders = () => {
  */
 exports.enableCookies = () => {
     cookieJar = request.jar()
+    cookieJar._jar.rejectPublicSuffixes = false
 }
 
 /**

--- a/src/extensions/http_api/definitions.js
+++ b/src/extensions/http_api/definitions.js
@@ -148,7 +148,7 @@ module.exports = ({ baseUrl = '' } = {}) => ({ Given, When, Then }) => {
     })
 
     /**
-     * Checking response cookie exists
+     * Checking response cookie is present|absent
      */
     Then(/^response should (not )?have an? (.+) cookie$/, function(flag, key) {
         const cookie = this.httpApiClient.getCookie(key)
@@ -161,7 +161,7 @@ module.exports = ({ baseUrl = '' } = {}) => ({ Given, When, Then }) => {
     })
 
     /**
-     * Checking response cookie secure
+     * Checking response cookie is|isn't secure
      */
     Then(/^response (.+) cookie should (not )?be secure$/, function(key, flag) {
         const cookie = this.httpApiClient.getCookie(key)

--- a/src/extensions/http_api/definitions.js
+++ b/src/extensions/http_api/definitions.js
@@ -177,7 +177,7 @@ module.exports = ({ baseUrl = '' } = {}) => ({ Given, When, Then }) => {
     /**
      * Checking response cookie httpOnly
      */
-    Then(/^response (.+) cookie should (not )?be http only/, function(key, flag) {
+    Then(/^response (.+) cookie should (not )?be http only$/, function(key, flag) {
         const cookie = this.httpApiClient.getCookie(key)
         expect(cookie, `No cookie found for key '${key}'`).to.not.be.null
 
@@ -185,6 +185,20 @@ module.exports = ({ baseUrl = '' } = {}) => ({ Given, When, Then }) => {
             expect(cookie.httpOnly, `Cookie '${key}' is not http only`).to.be.true
         } else {
             expect(cookie.httpOnly, `Cookie '${key}' is http only`).to.be.false
+        }
+    })
+
+    /**
+     * Checking response cookie domain
+     */
+    Then(/^response (.+) cookie domain should (not )?be (.+)$/, function(key, flag, domain) {
+        const cookie = this.httpApiClient.getCookie(key)
+        expect(cookie, `No cookie found for key '${key}'`).to.not.be.null
+
+        if (flag === undefined) {
+            expect(cookie.domain, `Expected cookie '${key}' domain to be '${domain}', found '${cookie.domain}'`).to.equal(domain)
+        } else {
+            expect(cookie.domain, `Cookie '${key}' domain is '${domain}'`).to.not.equal(domain)
         }
     })
 

--- a/src/extensions/http_api/definitions.js
+++ b/src/extensions/http_api/definitions.js
@@ -22,6 +22,13 @@ module.exports = ({ baseUrl = '' } = {}) => ({ Given, When, Then }) => {
     })
 
     /**
+     * Clearing headers
+     */
+    Given(/^(?:I )?clear request headers/, function() {
+        this.httpApiClient.clearHeaders()
+    })
+
+    /**
      * Setting json payload
      */
     Given(/^(?:I )?set request json body$/, function(step) {
@@ -53,6 +60,13 @@ module.exports = ({ baseUrl = '' } = {}) => ({ Given, When, Then }) => {
             console.log(data) // eslint-disable-line no-console
             this.httpApiClient.setFormBody(data)
         })
+    })
+
+    /**
+     * Clearing body
+     */
+    Given(/^(?:I )?clear request body$/, function() {
+        this.httpApiClient.clearBody()
     })
 
     /**

--- a/src/extensions/http_api/definitions.js
+++ b/src/extensions/http_api/definitions.js
@@ -69,6 +69,14 @@ module.exports = ({ baseUrl = '' } = {}) => ({ Given, When, Then }) => {
         this.state.set(key, _.get(body, path))
     })
 
+    Given(/^(?:I )?enable cookies$/, function() {
+        this.httpApiClient.enableCookieJar()
+    })
+
+    Given(/^(?:I )?disable cookies$/, function() {
+        this.httpApiClient.disableCookieJar()
+    })
+
     /**
      * Resetting the client's state
      */
@@ -96,8 +104,46 @@ module.exports = ({ baseUrl = '' } = {}) => ({ Given, When, Then }) => {
      */
     Then(/^(?:I )?should receive a ([1-5][0-9][0-9]) HTTP status code$/, function(statusCode) {
         const httpResponse = this.httpApiClient.getResponse()
-        expect(httpResponse).to.not.be.empty
-        expect(httpResponse.statusCode).to.equal(Number(statusCode))
+        expect(httpResponse, 'Response is empty').to.not.be.empty
+        expect(httpResponse.statusCode, `Expected status code to be: ${statusCode}, but found: ${httpResponse.statusCode}`).to.equal(
+            Number(statusCode)
+        )
+    })
+
+    /**
+     * Checking response cookie exists
+     */
+    Then(/^response should have a (.*) cookie$/, function(key) {
+        const cookie = this.httpApiClient.getCookie(key)
+        expect(cookie, `No cookie found for key ${key}`).to.not.be.null
+    })
+
+    /**
+     * Checking response cookie secure
+     */
+    Then(/^response (.*) cookie should (not )?be secure$/, function(key, flag) {
+        const cookie = this.httpApiClient.getCookie(key)
+        expect(cookie, `No cookie found for key ${key}`).to.not.be.null
+
+        if (flag === undefined) {
+            expect(cookie.secure, `Cookie ${key} is not secure`).to.be.true
+        } else {
+            expect(cookie.secure, `Cookie ${key} is secure`).to.be.false
+        }
+    })
+
+    /**
+     * Checking response cookie httpOnly
+     */
+    Then(/^response (.*) cookie should (not )?be http only/, function(key, flag) {
+        const cookie = this.httpApiClient.getCookie(key)
+        expect(cookie, `No cookie found for key ${key}`).to.not.be.null
+
+        if (flag === undefined) {
+            expect(cookie.httpOnly, `Cookie ${key} is not http only`).to.be.true
+        } else {
+            expect(cookie.httpOnly, `Cookie ${key} is http only`).to.be.false
+        }
     })
 
     /**

--- a/src/extensions/http_api/definitions.js
+++ b/src/extensions/http_api/definitions.js
@@ -150,36 +150,41 @@ module.exports = ({ baseUrl = '' } = {}) => ({ Given, When, Then }) => {
     /**
      * Checking response cookie exists
      */
-    Then(/^response should have a (.*) cookie$/, function(key) {
+    Then(/^response should (not )?have an? (.+) cookie$/, function(flag, key) {
         const cookie = this.httpApiClient.getCookie(key)
-        expect(cookie, `No cookie found for key ${key}`).to.not.be.null
+
+        if (flag === undefined) {
+            expect(cookie, `No cookie found for key '${key}'`).to.not.be.null
+        } else {
+            expect(cookie, `A cookie exists for key '${key}'`).to.be.null
+        }
     })
 
     /**
      * Checking response cookie secure
      */
-    Then(/^response (.*) cookie should (not )?be secure$/, function(key, flag) {
+    Then(/^response (.+) cookie should (not )?be secure$/, function(key, flag) {
         const cookie = this.httpApiClient.getCookie(key)
-        expect(cookie, `No cookie found for key ${key}`).to.not.be.null
+        expect(cookie, `No cookie found for key '${key}'`).to.not.be.null
 
         if (flag === undefined) {
-            expect(cookie.secure, `Cookie ${key} is not secure`).to.be.true
+            expect(cookie.secure, `Cookie '${key}' is not secure`).to.be.true
         } else {
-            expect(cookie.secure, `Cookie ${key} is secure`).to.be.false
+            expect(cookie.secure, `Cookie '${key}' is secure`).to.be.false
         }
     })
 
     /**
      * Checking response cookie httpOnly
      */
-    Then(/^response (.*) cookie should (not )?be http only/, function(key, flag) {
+    Then(/^response (.+) cookie should (not )?be http only/, function(key, flag) {
         const cookie = this.httpApiClient.getCookie(key)
-        expect(cookie, `No cookie found for key ${key}`).to.not.be.null
+        expect(cookie, `No cookie found for key '${key}'`).to.not.be.null
 
         if (flag === undefined) {
-            expect(cookie.httpOnly, `Cookie ${key} is not http only`).to.be.true
+            expect(cookie.httpOnly, `Cookie '${key}' is not http only`).to.be.true
         } else {
-            expect(cookie.httpOnly, `Cookie ${key} is http only`).to.be.false
+            expect(cookie.httpOnly, `Cookie '${key}' is http only`).to.be.false
         }
     })
 

--- a/src/extensions/http_api/definitions.js
+++ b/src/extensions/http_api/definitions.js
@@ -70,11 +70,11 @@ module.exports = ({ baseUrl = '' } = {}) => ({ Given, When, Then }) => {
     })
 
     Given(/^(?:I )?enable cookies$/, function() {
-        this.httpApiClient.enableCookieJar()
+        this.httpApiClient.enableCookies()
     })
 
     Given(/^(?:I )?disable cookies$/, function() {
-        this.httpApiClient.disableCookieJar()
+        this.httpApiClient.disableCookies()
     })
 
     /**
@@ -187,11 +187,11 @@ module.exports = ({ baseUrl = '' } = {}) => ({ Given, When, Then }) => {
     /**
      * This definition verify that an array for a given path has the expected length
      */
-    Then(/^(?:I )?should receive a collection of ([0-9]+) items?(?: for path )?(.+)?$/, function(itemsNumber, path) {
+    Then(/^(?:I )?should receive a collection of ([0-9]+) items?(?: for path )?(.+)?$/, function(size, path) {
         const { body } = this.httpApiClient.getResponse()
         const array = path !== undefined ? _.get(body, path) : body
 
-        expect(array.length).to.be.equal(Number(itemsNumber))
+        expect(array.length).to.be.equal(Number(size))
     })
 
     /**

--- a/src/extensions/http_api/definitions.js
+++ b/src/extensions/http_api/definitions.js
@@ -43,7 +43,6 @@ module.exports = ({ baseUrl = '' } = {}) => ({ Given, When, Then }) => {
      */
     Given(/^(?:I )?set request json body from (.+)$/, function(fixture) {
         return this.fixtures.load(fixture).then(data => {
-            console.log(data) // eslint-disable-line no-console
             this.httpApiClient.setJsonBody(data)
         })
     })
@@ -60,7 +59,6 @@ module.exports = ({ baseUrl = '' } = {}) => ({ Given, When, Then }) => {
      */
     Given(/^(?:I )?set request form body from (.+)$/, function(fixture) {
         return this.fixtures.load(fixture).then(data => {
-            console.log(data) // eslint-disable-line no-console
             this.httpApiClient.setFormBody(data)
         })
     })

--- a/tests/cast.test.js
+++ b/tests/cast.test.js
@@ -2,41 +2,41 @@
 
 const Cast = require('../src/cast')
 
-test('should cast nulls', () => {
+test('cast nulls', () => {
     expect(Cast.value('((null))')).toBe(null)
 })
 
-test('should cast undefined', () => {
+test('cast undefined', () => {
     expect(Cast.value('((undefined))')).toBe(undefined)
 })
 
-test('should cast numbers', () => {
+test('cast numbers', () => {
     expect(Cast.value('1((number))')).toBe(1)
     expect(Cast.value('.2((number))')).toBe(0.2)
     expect(Cast.value('-3((number))')).toBe(-3)
 })
 
-test('should throw when trying to cast invalid numbers', () => {
+test('throw when trying to cast invalid numbers', () => {
     expect(() => {
         Cast.value('nan((number))')
     }).toThrow(`Unable to cast value to number 'nan((number))'`)
 })
 
-test('should cast booleans', () => {
+test('cast booleans', () => {
     expect(Cast.value('true((boolean))')).toBe(true)
     expect(Cast.value('false((boolean))')).toBe(false)
 })
 
-test('should cast arrays', () => {
+test('cast arrays', () => {
     expect(Cast.value('one((array))')).toEqual(['one'])
     expect(Cast.value('one,2((number)),true((boolean))((array))')).toEqual(['one', 2, true])
 })
 
-test('should left value untouched if no casting directive were found', () => {
+test('left value untouched if no casting directive were found', () => {
     expect(Cast.value('untouched')).toBe('untouched')
 })
 
-test('should throw when type is invalid', () => {
+test('throw when type is invalid', () => {
     expect(() => {
         Cast.value('test((invalid))')
     }).toThrow(`Invalid type provided: invalid 'test((invalid))'`)

--- a/tests/cast.test.js
+++ b/tests/cast.test.js
@@ -16,6 +16,11 @@ test('cast numbers', () => {
     expect(Cast.value('-3((number))')).toBe(-3)
 })
 
+test('cast dates', () => {
+    expect(Cast.value('today((date))')).toMatch(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/)
+    expect(Cast.value('2010-10-10((date))')).toBe('2010-10-10T00:00:00.000Z')
+})
+
 test('throw when trying to cast invalid numbers', () => {
     expect(() => {
         Cast.value('nan((number))')
@@ -28,8 +33,13 @@ test('cast booleans', () => {
 })
 
 test('cast arrays', () => {
+    expect(Cast.value('((array))')).toEqual([])
     expect(Cast.value('one((array))')).toEqual(['one'])
     expect(Cast.value('one,2((number)),true((boolean))((array))')).toEqual(['one', 2, true])
+})
+
+test('cast strings', () => {
+    expect(Cast.value('yay((string))')).toEqual('yay')
 })
 
 test('left value untouched if no casting directive were found', () => {
@@ -40,4 +50,16 @@ test('throw when type is invalid', () => {
     expect(() => {
         Cast.value('test((invalid))')
     }).toThrow(`Invalid type provided: invalid 'test((invalid))'`)
+})
+
+test('cast array of values', () => {
+    expect(Cast.array(['1((number))', 'true((boolean))', 'a,b,c((array))'])).toEqual([1, true, ['a', 'b', 'c']])
+})
+
+test('cast array of objects', () => {
+    expect(Cast.objects([{ a: '1((number))' }, { b: 'true((boolean))' }, { c: 'a,b,c((array))' }])).toEqual([
+        { a: 1 },
+        { b: true },
+        { c: ['a', 'b', 'c'] }
+    ])
 })

--- a/tests/extensions/cli/definitions.test.js
+++ b/tests/extensions/cli/definitions.test.js
@@ -7,7 +7,7 @@ beforeEach(() => {
     require('chai').clear()
 })
 
-test('should allow to set current working directory', () => {
+test('set current working directory', () => {
     const context = helper.define(definitions)
 
     const def = context.getDefinitionByMatcher('set (?:working directory|cwd) to')
@@ -23,7 +23,7 @@ test('should allow to set current working directory', () => {
     expect(cliMock.cli.setCwd).toHaveBeenCalledWith('path')
 })
 
-test('should allow to set environment variables', () => {
+test('set environment variables', () => {
     const context = helper.define(definitions)
 
     const def = context.getDefinitionByMatcher('set (?:env|environment) (?:vars|variables)')
@@ -43,7 +43,7 @@ test('should allow to set environment variables', () => {
     expect(cliMock.cli.setEnvironmentVariables).toHaveBeenCalledWith(envVars)
 })
 
-test('should allow to set a single environment variable', () => {
+test('set a single environment variable', () => {
     const context = helper.define(definitions)
 
     const def = context.getDefinitionByMatcher('(?:env|environment) (?:var|variable)')
@@ -64,7 +64,7 @@ test('should allow to set a single environment variable', () => {
     expect(cliMock.cli.setEnvironmentVariable).toHaveBeenCalledWith('Accept', 'application/json')
 })
 
-test('should allow to schedule process killing', () => {
+test('schedule process killing', () => {
     const context = helper.define(definitions)
 
     const def = context.getDefinitionByMatcher('kill the process with')
@@ -84,7 +84,7 @@ test('should allow to schedule process killing', () => {
     expect(cliMock.cli.scheduleKillProcess).toHaveBeenCalledWith(10000, 'sig')
 })
 
-test('should allow to run a command', () => {
+test('run a command', () => {
     const context = helper.define(definitions)
 
     const def = context.getDefinitionByMatcher('run command')
@@ -92,9 +92,13 @@ test('should allow to run a command', () => {
     def.shouldNotMatch('I run command ')
     def.shouldMatch('I run command ls -al', ['ls -al'])
     def.shouldMatch('run command ls -al', ['ls -al'])
+
+    const cliMock = { cli: { run: jest.fn(() => Promise.resolve()) } }
+    def.exec(cliMock, 'ls -al')
+    expect(cliMock.cli.run).toHaveBeenCalledWith('ls -al')
 })
 
-test('should allow to dump stdout & stderr for debugging purpose', () => {
+test('dump stdout or stderr for debugging purpose', () => {
     const context = helper.define(definitions)
 
     const def = context.getDefinitionByMatcher('dump (stderr|stdout)')
@@ -110,7 +114,7 @@ test('should allow to dump stdout & stderr for debugging purpose', () => {
     expect(cliMock.cli.getOutput).toHaveBeenCalledWith('stdout')
 })
 
-test('should allow to check exit code', () => {
+test('check exit code', () => {
     const context = helper.define(definitions)
 
     const def = context.getDefinitionByMatcher('(?:command )?exit code should be')
@@ -128,7 +132,7 @@ test('should allow to check exit code', () => {
     expect(require('chai').equal).toHaveBeenCalledWith(0)
 })
 
-test('should allow to check if stdout or stderr is empty', () => {
+test('check if stdout or stderr is empty', () => {
     const context = helper.define(definitions)
 
     const def = context.getDefinitionByMatcher('(stderr|stdout) should be empty')
@@ -143,7 +147,7 @@ test('should allow to check if stdout or stderr is empty', () => {
     expect(require('chai').expect).toHaveBeenCalledWith('output')
 })
 
-test('should allow to check if stdout or stderr contains something', () => {
+test('check if stdout or stderr contains something', () => {
     const context = helper.define(definitions)
 
     const def = context.getDefinitionByMatcher('(stderr|stdout) should contain')
@@ -160,7 +164,7 @@ test('should allow to check if stdout or stderr contains something', () => {
     expect(require('chai').contain).toHaveBeenCalledWith('something')
 })
 
-test('should allow to check if stdout or stderr does not contain something', () => {
+test('check if stdout or stderr does not contain something', () => {
     const context = helper.define(definitions)
 
     const def = context.getDefinitionByMatcher('(stderr|stdout) should not contain')
@@ -177,7 +181,7 @@ test('should allow to check if stdout or stderr does not contain something', () 
     expect(require('chai').contain).toHaveBeenCalledWith('something')
 })
 
-test('should allow to check if stdout or stderr matches a regular expression', () => {
+test('check if stdout or stderr matches a regular expression', () => {
     const context = helper.define(definitions)
 
     const def = context.getDefinitionByMatcher('(stderr|stdout) should match')
@@ -194,7 +198,7 @@ test('should allow to check if stdout or stderr matches a regular expression', (
     expect(require('chai').match).toHaveBeenCalledWith(/something/gim)
 })
 
-test('should allow to check if stdout or stderr does not match a regular expression', () => {
+test('check if stdout or stderr does not match a regular expression', () => {
     const context = helper.define(definitions)
 
     const def = context.getDefinitionByMatcher('(stderr|stdout) should not match')

--- a/tests/extensions/http_api/definitions.test.js
+++ b/tests/extensions/http_api/definitions.test.js
@@ -201,7 +201,7 @@ test('check response HTTP status code', () => {
     const clientMock = { httpApiClient: { getResponse: jest.fn(() => ({ statusCode: 200 })) } }
     def.exec(clientMock, '200')
     expect(clientMock.httpApiClient.getResponse).toHaveBeenCalled()
-    expect(require('chai').expect).toHaveBeenCalledWith(200)
+    expect(require('chai').expect).toHaveBeenCalledWith(200, 'Expected status code to be: 200, but found: 200')
 })
 
 test('check json response', () => {

--- a/tests/extensions/http_api/definitions.test.js
+++ b/tests/extensions/http_api/definitions.test.js
@@ -241,19 +241,37 @@ test('dump response body', () => {
 test('check response HTTP status code', () => {
     const context = helper.define(definitions)
 
-    const def = context.getDefinitionByMatcher('HTTP status code')
+    const def = context.getDefinitionByMatcher('response status code should be')
     def.shouldHaveType('Then')
-    def.shouldNotMatch('I should receive a crap HTTP status code')
-    def.shouldNotMatch('I should receive a 600 HTTP status code')
-    def.shouldMatch('I should receive a 200 HTTP status code', ['200'])
-    def.shouldMatch('I should receive a 404 HTTP status code', ['404'])
-    def.shouldMatch('should receive a 200 HTTP status code', ['200'])
-    def.shouldMatch('should receive a 404 HTTP status code', ['404'])
+    def.shouldNotMatch('response status code should be ')
+    def.shouldNotMatch('response status code should be string')
+    def.shouldNotMatch('response status code should be 600')
+    def.shouldMatch('response status code should be 200', ['200'])
+    def.shouldMatch('response status code should be 404', ['404'])
 
     const clientMock = { httpApiClient: { getResponse: jest.fn(() => ({ statusCode: 200 })) } }
     def.exec(clientMock, '200')
     expect(clientMock.httpApiClient.getResponse).toHaveBeenCalled()
     expect(require('chai').expect).toHaveBeenCalledWith(200, 'Expected status code to be: 200, but found: 200')
+})
+
+test('check response HTTP status by message', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('response status should be')
+    def.shouldHaveType('Then')
+    def.shouldNotMatch('response status should be ')
+    def.shouldMatch('response status should be ok', ['ok'])
+    def.shouldMatch('response status should be forbidden', ['forbidden'])
+
+    const clientMock = { httpApiClient: { getResponse: jest.fn(() => ({ statusCode: 200 })) } }
+    def.exec(clientMock, 'ok')
+    expect(clientMock.httpApiClient.getResponse).toHaveBeenCalled()
+    expect(require('chai').expect).toHaveBeenCalledWith(200, `Expected status to be: 'ok', but found: 'ok'`)
+
+    expect(() => {
+        def.exec(clientMock, 'invalid')
+    }).toThrow(new TypeError(`'invalid' is not a valid status message`))
 })
 
 test('check json response', () => {

--- a/tests/extensions/http_api/definitions.test.js
+++ b/tests/extensions/http_api/definitions.test.js
@@ -286,6 +286,36 @@ test('test cookie is not http only', () => {
     expect(require('chai').expect).toHaveBeenCalledWith(false, `Cookie 'test' is http only`)
 })
 
+test('test cookie domain equals given value', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('response (.+) cookie domain should (not )?be (.+)')
+    def.shouldHaveType('Then')
+    def.shouldNotMatch('response  cookie domain should be domain')
+    def.shouldNotMatch('response test cookie domain should be ')
+    def.shouldMatch('response test cookie domain should be domain', ['test', undefined, 'domain'])
+
+    const clientMock = { httpApiClient: { getCookie: jest.fn(() => ({ domain: 'domain' })) } }
+    def.exec(clientMock, 'test', undefined, 'domain')
+    expect(clientMock.httpApiClient.getCookie).toHaveBeenCalledWith('test')
+    expect(require('chai').expect).toHaveBeenCalledWith('domain', `Expected cookie 'test' domain to be 'domain', found 'domain'`)
+})
+
+test('test cookie domain does not equal given value', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('response (.+) cookie domain should (not )?be (.+)')
+    def.shouldHaveType('Then')
+    def.shouldNotMatch('response  cookie domain should not be domain')
+    def.shouldNotMatch('response test cookie domain should not be ')
+    def.shouldMatch('response test cookie domain should not be domain', ['test', 'not ', 'domain'])
+
+    const clientMock = { httpApiClient: { getCookie: jest.fn(() => ({ domain: 'domain' })) } }
+    def.exec(clientMock, 'test', 'not ', 'domain')
+    expect(clientMock.httpApiClient.getCookie).toHaveBeenCalledWith('test')
+    expect(require('chai').expect).toHaveBeenCalledWith('domain', `Cookie 'test' domain is 'domain'`)
+})
+
 test('reset http client', () => {
     const context = helper.define(definitions)
 

--- a/tests/extensions/http_api/definitions.test.js
+++ b/tests/extensions/http_api/definitions.test.js
@@ -112,13 +112,13 @@ test('set request form body from fixture file', () => {
     def.shouldMatch('I set request form body from fixture')
     def.shouldMatch('set request form body from fixture')
 
-    const fixture   = {
+    const fixture = {
         is_active: 'true',
-        id:        '2'
+        id: '2'
     }
     const worldMock = {
-        httpApiClient: {setFormBody: jest.fn()},
-        fixtures:      {load: jest.fn(() => Promise.resolve(fixture))}
+        httpApiClient: { setFormBody: jest.fn() },
+        fixtures: { load: jest.fn(() => Promise.resolve(fixture)) }
     }
 
     return def.exec(worldMock, 'fixture').then(() => {

--- a/tests/extensions/http_api/definitions.test.js
+++ b/tests/extensions/http_api/definitions.test.js
@@ -230,6 +230,34 @@ test('test cookie is absent', () => {
     expect(require('chai').expect).toHaveBeenCalledWith(undefined, `A cookie exists for key 'test'`)
 })
 
+test('test cookie is secure', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('response (.+) cookie should (not )?be secure')
+    def.shouldHaveType('Then')
+    def.shouldNotMatch('response  cookie should be secure')
+    def.shouldMatch('response test cookie should be secure', ['test', undefined])
+
+    const clientMock = { httpApiClient: { getCookie: jest.fn(() => ({ secure: true })) } }
+    def.exec(clientMock, 'test', undefined)
+    expect(clientMock.httpApiClient.getCookie).toHaveBeenCalledWith('test')
+    expect(require('chai').expect).toHaveBeenCalledWith(true, `Cookie 'test' is not secure`)
+})
+
+test('test cookie is not secure', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('response (.+) cookie should (not )?be secure')
+    def.shouldHaveType('Then')
+    def.shouldNotMatch('response  cookie should not be secure')
+    def.shouldMatch('response test cookie should not be secure', ['test', 'not '])
+
+    const clientMock = { httpApiClient: { getCookie: jest.fn(() => ({ secure: false })) } }
+    def.exec(clientMock, 'test', 'not ')
+    expect(clientMock.httpApiClient.getCookie).toHaveBeenCalledWith('test')
+    expect(require('chai').expect).toHaveBeenCalledWith(false, `Cookie 'test' is secure`)
+})
+
 test('reset http client', () => {
     const context = helper.define(definitions)
 
@@ -337,7 +365,7 @@ test('check json collection size for a given path', () => {
     expect(require('chai').equal).toHaveBeenCalledWith(3)
 })
 
-test('match snapshot', () => {
+test('response match snapshot', () => {
     const context = helper.define(definitions)
 
     expect.assertions(5)

--- a/tests/extensions/http_api/definitions.test.js
+++ b/tests/extensions/http_api/definitions.test.js
@@ -258,6 +258,34 @@ test('test cookie is not secure', () => {
     expect(require('chai').expect).toHaveBeenCalledWith(false, `Cookie 'test' is secure`)
 })
 
+test('test cookie is http only', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('response (.+) cookie should (not )?be http only')
+    def.shouldHaveType('Then')
+    def.shouldNotMatch('response  cookie should be http only')
+    def.shouldMatch('response test cookie should be http only', ['test', undefined])
+
+    const clientMock = { httpApiClient: { getCookie: jest.fn(() => ({ httpOnly: true })) } }
+    def.exec(clientMock, 'test', undefined)
+    expect(clientMock.httpApiClient.getCookie).toHaveBeenCalledWith('test')
+    expect(require('chai').expect).toHaveBeenCalledWith(true, `Cookie 'test' is not http only`)
+})
+
+test('test cookie is not http only', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('response (.+) cookie should (not )?be http only')
+    def.shouldHaveType('Then')
+    def.shouldNotMatch('response  cookie should not be http only')
+    def.shouldMatch('response test cookie should not be http only', ['test', 'not '])
+
+    const clientMock = { httpApiClient: { getCookie: jest.fn(() => ({ httpOnly: false })) } }
+    def.exec(clientMock, 'test', 'not ')
+    expect(clientMock.httpApiClient.getCookie).toHaveBeenCalledWith('test')
+    expect(require('chai').expect).toHaveBeenCalledWith(false, `Cookie 'test' is http only`)
+})
+
 test('reset http client', () => {
     const context = helper.define(definitions)
 

--- a/tests/extensions/http_api/definitions.test.js
+++ b/tests/extensions/http_api/definitions.test.js
@@ -144,6 +144,32 @@ test('pick response json property', () => {
     def.shouldMatch('pick response json key as value', ['key', 'value'])
 })
 
+test('enable cookies', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('enable cookies')
+    def.shouldHaveType('Given')
+    def.shouldMatch('I enable cookies')
+    def.shouldMatch('enable cookies')
+
+    const clientMock = { httpApiClient: { enableCookies: jest.fn() } }
+    def.exec(clientMock)
+    expect(clientMock.httpApiClient.enableCookies).toHaveBeenCalled()
+})
+
+test('disable cookies', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('disable cookies')
+    def.shouldHaveType('Given')
+    def.shouldMatch('I disable cookies')
+    def.shouldMatch('disable cookies')
+
+    const clientMock = { httpApiClient: { disableCookies: jest.fn() } }
+    def.exec(clientMock)
+    expect(clientMock.httpApiClient.disableCookies).toHaveBeenCalled()
+})
+
 test('reset http client', () => {
     const context = helper.define(definitions)
 
@@ -225,6 +251,12 @@ test('check json collection size for a given path', () => {
     def.shouldMatch('I should receive a collection of 2 items for path property', ['2', 'property'])
     def.shouldMatch('should receive a collection of 1 item for path property', ['1', 'property'])
     def.shouldMatch('should receive a collection of 2 items', ['2', undefined])
+
+    const clientMock = { httpApiClient: { getResponse: jest.fn(() => ({ body: { property: ['a', 'b', 'c'] } })) } }
+    def.exec(clientMock, '3', 'property')
+    expect(clientMock.httpApiClient.getResponse).toHaveBeenCalled()
+    expect(require('chai').expect).toHaveBeenCalledWith(3)
+    expect(require('chai').equal).toHaveBeenCalledWith(3)
 })
 
 test('match snapshot', () => {

--- a/tests/extensions/http_api/definitions.test.js
+++ b/tests/extensions/http_api/definitions.test.js
@@ -196,6 +196,40 @@ test('disable cookies', () => {
     expect(clientMock.httpApiClient.disableCookies).toHaveBeenCalled()
 })
 
+test('test cookie is present', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('response should (not )?have an? (.+) cookie')
+    def.shouldHaveType('Then')
+    def.shouldNotMatch('response should have a  cookie')
+    def.shouldNotMatch('response should have an  cookie')
+    def.shouldMatch('response should have a test cookie', [undefined, 'test'])
+    def.shouldMatch('response should have an test cookie', [undefined, 'test'])
+
+    const clientMock = { httpApiClient: { getCookie: jest.fn() } }
+    def.exec(clientMock, undefined, 'test')
+    expect(clientMock.httpApiClient.getCookie).toHaveBeenCalledWith('test')
+    expect(require('chai').expect).toHaveBeenCalledWith(undefined, `No cookie found for key 'test'`)
+})
+
+test('test cookie is absent', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('response should (not )?have an? (.+) cookie')
+    def.shouldHaveType('Then')
+    def.shouldNotMatch('response should crap have a  cookie')
+    def.shouldNotMatch('response should crap have an  cookie')
+    def.shouldNotMatch('response should not have a  cookie')
+    def.shouldNotMatch('response should not have an  cookie')
+    def.shouldMatch('response should not have a test cookie', ['not ', 'test'])
+    def.shouldMatch('response should not have an test cookie', ['not ', 'test'])
+
+    const clientMock = { httpApiClient: { getCookie: jest.fn() } }
+    def.exec(clientMock, 'not ', 'test')
+    expect(clientMock.httpApiClient.getCookie).toHaveBeenCalledWith('test')
+    expect(require('chai').expect).toHaveBeenCalledWith(undefined, `A cookie exists for key 'test'`)
+})
+
 test('reset http client', () => {
     const context = helper.define(definitions)
 

--- a/tests/extensions/http_api/definitions.test.js
+++ b/tests/extensions/http_api/definitions.test.js
@@ -44,6 +44,19 @@ test('set a single request header', () => {
     expect(clientMock.httpApiClient.setHeader).toHaveBeenCalledWith('Accept', 'test')
 })
 
+test('clear request headers', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('clear request headers')
+    def.shouldHaveType('Given')
+    def.shouldMatch('I clear request headers')
+    def.shouldMatch('clear request headers')
+
+    const clientMock = { httpApiClient: { clearHeaders: jest.fn() } }
+    def.exec(clientMock)
+    expect(clientMock.httpApiClient.clearHeaders).toHaveBeenCalled()
+})
+
 test('set request json body', () => {
     const context = helper.define(definitions)
 
@@ -99,19 +112,32 @@ test('set request form body from fixture file', () => {
     def.shouldMatch('I set request form body from fixture')
     def.shouldMatch('set request form body from fixture')
 
-    const fixture = {
+    const fixture   = {
         is_active: 'true',
-        id: '2'
+        id:        '2'
     }
     const worldMock = {
-        httpApiClient: { setFormBody: jest.fn() },
-        fixtures: { load: jest.fn(() => Promise.resolve(fixture)) }
+        httpApiClient: {setFormBody: jest.fn()},
+        fixtures:      {load: jest.fn(() => Promise.resolve(fixture))}
     }
 
     return def.exec(worldMock, 'fixture').then(() => {
         expect(worldMock.fixtures.load).toHaveBeenCalledWith('fixture')
         expect(worldMock.httpApiClient.setFormBody).toHaveBeenCalledWith(fixture)
     })
+})
+
+test('clear request body', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('clear request body')
+    def.shouldHaveType('Given')
+    def.shouldMatch('I clear request body')
+    def.shouldMatch('clear request body')
+
+    const clientMock = { httpApiClient: { clearBody: jest.fn() } }
+    def.exec(clientMock)
+    expect(clientMock.httpApiClient.clearBody).toHaveBeenCalled()
 })
 
 test('set request query', () => {

--- a/tests/extensions/state/definitions.test.js
+++ b/tests/extensions/state/definitions.test.js
@@ -3,7 +3,7 @@
 const helper = require('../definitions_helper')
 const definitions = require('../../../src/extensions/state/definitions')
 
-test('should allow to set a state property', () => {
+test('set state property', () => {
     const context = helper.define(definitions)
 
     const def = context.getDefinitionByMatcher('set state (.+) to')
@@ -17,7 +17,7 @@ test('should allow to set a state property', () => {
     expect(stateMock.state.set).toHaveBeenCalledWith('property', 'value')
 })
 
-test('should allow to clear state', () => {
+test('clear state', () => {
     const context = helper.define(definitions)
 
     const def = context.getDefinitionByMatcher('clear state')
@@ -30,7 +30,7 @@ test('should allow to clear state', () => {
     expect(stateMock.state.clear).toHaveBeenCalled()
 })
 
-test('should allow to dump current state', () => {
+test('dump current state', () => {
     const context = helper.define(definitions)
 
     const def = context.getDefinitionByMatcher('dump state')

--- a/yarn.lock
+++ b/yarn.lock
@@ -2297,6 +2297,10 @@ qs@~6.3.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
 
+qs@~6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"


### PR DESCRIPTION
### Add new definitions for http API extension:

**Given**
- `/^(?:I )?clear request headers/`
- `/^(?:I )?clear request body$/`
- `/^(?:I )?enable cookies$/`
- `/^(?:I )?disable cookies$/`

**Then**
- `/^response status should be (.+)$/`
- `/^response should have a (.*) cookie$/`
- `/^response (.*) cookie should (not )?be secure$/`
- `/^response (.*) cookie should (not )?be http only/`

⚠️ Definitions updates:

**Then**
- `/^(?:I )?should receive a ([1-5][0-9][0-9]) HTTP status code$/` => `/^response status code should be ([1-5][0-9][0-9])$/`
