### PR TITLE
feat(state): use state for check response step definition

### DIFF
--- a/src/extensions/http_api/definitions.js
+++ b/src/extensions/http_api/definitions.js
@@ -92,20 +92,22 @@ module.exports = ({ baseUrl = '' }) => ({ Given, When, Then }) => {
         const response = this.httpApiClient.getResponse()
         const body = response.body
 
-        const expectedProperties = Cast.objects(table.hashes())
+        const expectedProperties = table.hashes()
 
         // We check the response has json content-type
         expect(response.headers['content-type']).to.contain('application/json')
 
         // We check response properties correspond to the expected response
         expectedProperties.forEach(propertyMatcher => {
+            const expectedValue = Cast.value(this.state.populate(propertyMatcher.value))
+
             switch (propertyMatcher.matcher) {
                 case 'contains':
-                    expect(_.get(body, propertyMatcher.field)).to.contain(propertyMatcher.value)
+                    expect(_.get(body, propertyMatcher.field)).to.contain(expectedValue)
                     break
                 case 'equals':
                 default:
-                    expect(_.get(body, propertyMatcher.field)).to.be.equal(propertyMatcher.value)
+                    expect(_.get(body, propertyMatcher.field)).to.be.equal(expectedValue)
             }
         })
 

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const state = require('../src/extensions/state/state')
+
+test('should return null value', () => {
+    expect(state.populate('((null))')).toBe('((null))')
+})
+
+test('should return undefined value', () => {
+    expect(state.populate('((undefined))')).toBe('((undefined))')
+})
+
+test('should populate value with state data', () => {
+    state.clear()
+    state.set('key1', '1')
+    expect(state.populate('{{key1}}')).toBe('1')
+    expect(state.populate('{{key1}}((number))')).toBe('1((number))')
+})
+
+test('should returned complete object populated with the state data', () => {
+    state.clear()
+    state.set('key1', 'value1')
+    state.set('key2', '2')
+
+    const object = {
+        field1: '{{key1}}',
+        object2: {
+            field1: '1((number))',
+            field2: '{{key2}}((number))'
+        }
+    }
+
+    const expectedObject = {
+        field1: 'value1',
+        object2: {
+            field1: '1((number))',
+            field2: '2((number))'
+        }
+    }
+
+    expect(state.populateObject(object)).toEqual(expectedObject)
+})


### PR DESCRIPTION
It is possible now to use state's placeholder when checking response.