### PR TITLE
Add missing tests on step definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "gherkin",
     "testing",
     "api",
+    "http",
     "cli"
   ],
   "repository": {
@@ -23,7 +24,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node" : ">=6.0.0"
+    "node": ">=6.0.0"
   },
   "engineStrict": true,
   "dependencies": {
@@ -45,11 +46,11 @@
     "cucumber": "^2.3.1"
   },
   "scripts": {
-    "test": "jest",
-    "test-cover": "jest --coverage",
+    "test": "jest --verbose",
+    "test-cover": "jest --verbose --coverage",
     "coverage": "cat ./coverage/lcov.info | coveralls",
-    "fmt": "prettier --print-width 140 --tab-width=4 --single-quote --bracket-spacing --no-semi --color --write \"src/**/*.js\"",
-    "check-fmt": "prettier --print-width 140 --tab-width=4 --single-quote --bracket-spacing --no-semi --list-different \"src/**/*.js\"",
+    "fmt": "prettier --print-width 140 --tab-width=4 --single-quote --bracket-spacing --no-semi --color --write \"{src,tests}/**/*.js\"",
+    "check-fmt": "prettier --print-width 140 --tab-width=4 --single-quote --bracket-spacing --no-semi --list-different \"{src,tests}/**/*.js\"",
     "version": "echo ${npm_package_version}",
     "lint": "eslint .",
     "doc": "jsdoc src -R README.md -r -d doc --verbose -t node_modules/minami",

--- a/src/extensions/cli/definitions.js
+++ b/src/extensions/cli/definitions.js
@@ -3,11 +3,11 @@
 const { expect } = require('chai')
 
 module.exports = ({ Given, When, Then }) => {
-    Given(/^I set (?:working directory|cwd) to (.+)$/, function(cwd) {
+    Given(/^(?:I )?set (?:working directory|cwd) to (.+)$/, function(cwd) {
         this.cli.setCwd(cwd)
     })
 
-    Given(/^(?:I )?set (?:env|environment) (?:var|variable) ([^ ]+): (.*)$/, function(name, value) {
+    Given(/^(?:I )?set ([^ ]+) (?:env|environment) (?:var|variable) to (.+)$/, function(name, value) {
         this.cli.setEnvironmentVariable(name, value)
     })
 
@@ -24,7 +24,7 @@ module.exports = ({ Given, When, Then }) => {
         this.cli.scheduleKillProcess(delay, signal)
     })
 
-    When(/^I run command (.+)$/, function(command, callback) {
+    When(/^(?:I )?run command (.+)$/, function(command, callback) {
         this.cli
             .run(command)
             .then(() => {
@@ -35,7 +35,7 @@ module.exports = ({ Given, When, Then }) => {
             })
     })
 
-    When(/^(?:I )?dump (stderr|stdout)/, function(type) {
+    When(/^(?:I )?dump (stderr|stdout)$/, function(type) {
         const output = this.cli.getOutput(type)
         console.log(output) // eslint-disable-line no-console
     })
@@ -48,31 +48,31 @@ module.exports = ({ Given, When, Then }) => {
         )
     })
 
-    Then(/^(?:the )?(?:command )?(stderr|stdout) should be empty$/, function(type) {
+    Then(/^(stderr|stdout) should be empty$/, function(type) {
         const output = this.cli.getOutput(type)
 
         expect(output).to.be.empty
     })
 
-    Then(/^(?:the )?(?:command )?(stderr|stdout) should contain (.+)$/, function(type, expected) {
+    Then(/^(stderr|stdout) should contain (.+)$/, function(type, expected) {
         const output = this.cli.getOutput(type)
 
         expect(output).to.contain(expected)
     })
 
-    Then(/^(?:the )?(?:command )?(stderr|stdout) should not contain (.+)$/, function(type, expected) {
+    Then(/^(stderr|stdout) should not contain (.+)$/, function(type, expected) {
         const output = this.cli.getOutput(type)
 
         expect(output).to.not.contain(expected)
     })
 
-    Then(/^(?:the )?(?:command )?(stderr|stdout) should match (.+)$/, function(type, regex) {
+    Then(/^(stderr|stdout) should match (.+)$/, function(type, regex) {
         const output = this.cli.getOutput(type)
 
         expect(output).to.match(new RegExp(regex, 'gim'))
     })
 
-    Then(/^(?:the )?(?:command )?(stderr|stdout) should not match (.+)$/, function(type, regex) {
+    Then(/^(stderr|stdout) should not match (.+)$/, function(type, regex) {
         const output = this.cli.getOutput(type)
 
         expect(output).to.not.match(new RegExp(regex, 'gim'))

--- a/src/extensions/http_api/definitions.js
+++ b/src/extensions/http_api/definitions.js
@@ -6,7 +6,7 @@ const _ = require('lodash')
 const Cast = require('../../cast')
 const Helper = require('../../helper')
 
-module.exports = ({ baseUrl = '' }) => ({ Given, When, Then }) => {
+module.exports = ({ baseUrl = '' } = {}) => ({ Given, When, Then }) => {
     /**
      * Setting http headers
      */
@@ -17,7 +17,7 @@ module.exports = ({ baseUrl = '' }) => ({ Given, When, Then }) => {
     /**
      * Setting a single http header
      */
-    Given(/^(?:I )?set ([a-zA-Z0-9-]+) request header to (.*)$/, function(key, value) {
+    Given(/^(?:I )?set ([a-zA-Z0-9-]+) request header to (.+)$/, function(key, value) {
         this.httpApiClient.setHeader(key, Cast.value(this.state.populate(value)))
     })
 
@@ -42,7 +42,7 @@ module.exports = ({ baseUrl = '' }) => ({ Given, When, Then }) => {
         this.httpApiClient.setQuery(Cast.object(this.state.populateObject(step.rowsHash())))
     })
 
-    Given(/^(?:I )?pick response json (.*) as (.*)$/, function(path, key) {
+    Given(/^(?:I )?pick response json (.+) as (.+)$/, function(path, key) {
         const response = this.httpApiClient.getResponse()
         const body = response.body
 
@@ -52,14 +52,14 @@ module.exports = ({ baseUrl = '' }) => ({ Given, When, Then }) => {
     /**
      * Resetting the client's state
      */
-    When(/^(?:I )?reset http client/, function() {
+    When(/^(?:I )?reset http client$/, function() {
         this.httpApiClient.reset()
     })
 
     /**
      * Performing a request
      */
-    When(/^(?:I )?(GET|POST|PUT|DELETE) (.*)$/, function(method, path) {
+    When(/^(?:I )?(GET|POST|PUT|DELETE) (.+)$/, function(method, path) {
         return this.httpApiClient.makeRequest(method, this.state.populate(path), baseUrl)
     })
 
@@ -88,7 +88,7 @@ module.exports = ({ baseUrl = '' }) => ({ Given, When, Then }) => {
      * - equals
      * - contains
      */
-    Then(/^(?:I )?should receive a json response (fully )?matching/, function(fully, table) {
+    Then(/^(?:I )?should receive a json response (fully )?matching$/, function(fully, table) {
         const response = this.httpApiClient.getResponse()
         const body = response.body
 
@@ -119,7 +119,7 @@ module.exports = ({ baseUrl = '' }) => ({ Given, When, Then }) => {
     /**
      * This definition verify that an array for a given path has the expected length
      */
-    Then(/^(?:I )?should receive a collection of (\d+) items for path '(.*)'/, function(itemsNumber, path) {
+    Then(/^(?:I )?should receive a collection of (\d+) items? for path (.+)$/, function(itemsNumber, path) {
         const { body } = this.httpApiClient.getResponse()
         const array = _.get(body, path)
 

--- a/src/extensions/state/definitions.js
+++ b/src/extensions/state/definitions.js
@@ -1,15 +1,13 @@
 'use strict'
 
-const _ = require('lodash')
-
 const Cast = require('../../cast')
 
 module.exports = ({ Given, When }) => {
-    Given(/^(?:I )?set state key (.*) to (.*)$/, (key, value) => {
+    Given(/^(?:I )?set state (.+) to (.+)$/, (key, value) => {
         this.state.set(key, Cast.value(value))
     })
 
-    Given(/^(?:I )?clear state$/, function() {
+    When(/^(?:I )?clear state$/, function() {
         this.state.clear()
     })
 

--- a/src/extensions/state/definitions.js
+++ b/src/extensions/state/definitions.js
@@ -3,7 +3,7 @@
 const Cast = require('../../cast')
 
 module.exports = ({ Given, When }) => {
-    Given(/^(?:I )?set state (.+) to (.+)$/, (key, value) => {
+    Given(/^(?:I )?set state (.+) to (.+)$/, function(key, value) {
         this.state.set(key, Cast.value(value))
     })
 

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,5 +1,29 @@
 'use strict'
 
+/**
+ * Count object properties including nested objects ones.
+ * If a property is an object, its key is ignored.
+ *
+ * @example
+ * Helper.countNestedProperties({
+ *     a: true,
+ *     b: true,
+ *     c: true,
+ * })
+ * // => 3
+ * Helper.countNestedProperties({
+ *     a: true,
+ *     b: true,
+ *     c: {
+ *         a: true,
+ *         b: true,
+ *     },
+ * })
+ * // => 4 (c is ignored because it's a nested object)
+ *
+ * @param {Object} object
+ * @return {number}
+ */
 exports.countNestedProperties = object => {
     let propertiesCount = 0
     Object.keys(object).forEach(key => {
@@ -14,11 +38,24 @@ exports.countNestedProperties = object => {
     return propertiesCount
 }
 
+/**
+ * Registers an extension.
+ *
+ * @param {Object} world       - Cucumber world object
+ * @param {string} extensionId - Unique veggies extension identifier
+ */
 exports.registerExtension = (world, extensionId) => {
     world._registredExtensions = world._registredExtensions || []
     world._registredExtensions.push(extensionId)
 }
 
+/**
+ * Checks if an extension were registered.
+ *
+ * @param {Object} world       - Cucumber world object
+ * @param {string} extensionId - Unique veggies extension identifier
+ * @return {boolean}
+ */
 exports.hasExtension = (world, extensionId) => {
     if (!world._registredExtensions) return false
     if (!world._registredExtensions.includes(extensionId)) return false

--- a/tests/__mocks__/chai.js
+++ b/tests/__mocks__/chai.js
@@ -1,0 +1,36 @@
+'use strict'
+
+jest.mock('../../node_modules/chai/lib/chai/config', () => ({
+    useProxy: false
+}))
+
+const chai = jest.genMockFromModule('chai')
+
+const equal = jest.fn()
+const contain = jest.fn()
+const match = jest.fn()
+
+const chainable = {
+    equal,
+    contain,
+    match
+}
+
+chainable.to = chainable
+chainable.be = chainable
+chainable.not = chainable
+chainable.empty = chainable
+
+const expect = jest.fn(() => chainable)
+
+exports.expect = expect
+exports.equal = equal
+exports.contain = contain
+exports.match = match
+
+exports.clear = () => {
+    expect.mockClear()
+    equal.mockClear()
+    contain.mockClear()
+    match.mockClear()
+}

--- a/tests/cast.test.js
+++ b/tests/cast.test.js
@@ -12,7 +12,7 @@ test('should cast undefined', () => {
 
 test('should cast numbers', () => {
     expect(Cast.value('1((number))')).toBe(1)
-    expect(Cast.value('.2((number))')).toBe(.2)
+    expect(Cast.value('.2((number))')).toBe(0.2)
     expect(Cast.value('-3((number))')).toBe(-3)
 })
 

--- a/tests/extensions/cli/definitions.test.js
+++ b/tests/extensions/cli/definitions.test.js
@@ -3,6 +3,10 @@
 const helper = require('../definitions_helper')
 const definitions = require('../../../src/extensions/cli/definitions')
 
+beforeEach(() => {
+    require('chai').clear()
+})
+
 test('should allow to set current working directory', () => {
     const context = helper.define(definitions)
 
@@ -13,6 +17,10 @@ test('should allow to set current working directory', () => {
     def.shouldMatch('I set cwd to path', ['path'])
     def.shouldMatch('set working directory to path', ['path'])
     def.shouldMatch('set cwd to path', ['path'])
+
+    const cliMock = { cli: { setCwd: jest.fn() } }
+    def.exec(cliMock, 'path')
+    expect(cliMock.cli.setCwd).toHaveBeenCalledWith('path')
 })
 
 test('should allow to set environment variables', () => {
@@ -28,6 +36,11 @@ test('should allow to set environment variables', () => {
     def.shouldMatch('set environment vars')
     def.shouldMatch('set env variables')
     def.shouldMatch('set env vars')
+
+    const cliMock = { cli: { setEnvironmentVariables: jest.fn() } }
+    const envVars = { TEST_MODE: true }
+    def.exec(cliMock, { rowsHash: () => envVars })
+    expect(cliMock.cli.setEnvironmentVariables).toHaveBeenCalledWith(envVars)
 })
 
 test('should allow to set a single environment variable', () => {
@@ -45,6 +58,10 @@ test('should allow to set a single environment variable', () => {
     def.shouldMatch('set Accept environment var to application/json')
     def.shouldMatch('set Accept env variable to application/json')
     def.shouldMatch('set Accept env var to application/json')
+
+    const cliMock = { cli: { setEnvironmentVariable: jest.fn() } }
+    def.exec(cliMock, 'Accept', 'application/json')
+    expect(cliMock.cli.setEnvironmentVariable).toHaveBeenCalledWith('Accept', 'application/json')
 })
 
 test('should allow to schedule process killing', () => {
@@ -59,6 +76,12 @@ test('should allow to schedule process killing', () => {
     def.shouldMatch('I kill the process with sig in 10ms', ['sig', '10', 'ms'])
     def.shouldMatch('kill the process with sig in 1s', ['sig', '1', 's'])
     def.shouldMatch('kill the process with sig in 10ms', ['sig', '10', 'ms'])
+
+    const cliMock = { cli: { scheduleKillProcess: jest.fn() } }
+    def.exec(cliMock, 'sig', '10', 'ms')
+    expect(cliMock.cli.scheduleKillProcess).toHaveBeenCalledWith(10, 'sig')
+    def.exec(cliMock, 'sig', '10', 's')
+    expect(cliMock.cli.scheduleKillProcess).toHaveBeenCalledWith(10000, 'sig')
 })
 
 test('should allow to run a command', () => {
@@ -81,6 +104,10 @@ test('should allow to dump stdout & stderr for debugging purpose', () => {
     def.shouldMatch('I dump stderr', ['stderr'])
     def.shouldMatch('dump stdout', ['stdout'])
     def.shouldMatch('dump stderr', ['stderr'])
+
+    const cliMock = { cli: { getOutput: jest.fn() } }
+    def.exec(cliMock, 'stdout')
+    expect(cliMock.cli.getOutput).toHaveBeenCalledWith('stdout')
 })
 
 test('should allow to check exit code', () => {
@@ -93,6 +120,12 @@ test('should allow to check exit code', () => {
     def.shouldMatch('the command exit code should be 1', ['1'])
     def.shouldMatch('command exit code should be 0', ['0'])
     def.shouldMatch('exit code should be 32', ['32'])
+
+    const cliMock = { cli: { getExitCode: jest.fn(() => 0) } }
+    def.exec(cliMock, '0')
+    expect(cliMock.cli.getExitCode).toHaveBeenCalled()
+    expect(require('chai').expect).toHaveBeenCalledWith(0, `The command exit code doesn't match expected 0, found: 0`)
+    expect(require('chai').equal).toHaveBeenCalledWith(0)
 })
 
 test('should allow to check if stdout or stderr is empty', () => {
@@ -103,6 +136,11 @@ test('should allow to check if stdout or stderr is empty', () => {
     def.shouldNotMatch('stdcrap should be empty')
     def.shouldMatch('stdout should be empty', ['stdout'])
     def.shouldMatch('stderr should be empty', ['stderr'])
+
+    const cliMock = { cli: { getOutput: jest.fn(() => 'output') } }
+    def.exec(cliMock, 'stdout')
+    expect(cliMock.cli.getOutput).toHaveBeenCalledWith('stdout')
+    expect(require('chai').expect).toHaveBeenCalledWith('output')
 })
 
 test('should allow to check if stdout or stderr contains something', () => {
@@ -114,6 +152,12 @@ test('should allow to check if stdout or stderr contains something', () => {
     def.shouldNotMatch('stdout should contain ')
     def.shouldMatch('stdout should contain something', ['stdout', 'something'])
     def.shouldMatch('stderr should contain something', ['stderr', 'something'])
+
+    const cliMock = { cli: { getOutput: jest.fn(() => 'output') } }
+    def.exec(cliMock, 'stdout', 'something')
+    expect(cliMock.cli.getOutput).toHaveBeenCalledWith('stdout')
+    expect(require('chai').expect).toHaveBeenCalledWith('output')
+    expect(require('chai').contain).toHaveBeenCalledWith('something')
 })
 
 test('should allow to check if stdout or stderr does not contain something', () => {
@@ -125,6 +169,12 @@ test('should allow to check if stdout or stderr does not contain something', () 
     def.shouldNotMatch('stdout should not contain ')
     def.shouldMatch('stdout should not contain something', ['stdout', 'something'])
     def.shouldMatch('stderr should not contain something', ['stderr', 'something'])
+
+    const cliMock = { cli: { getOutput: jest.fn(() => 'output') } }
+    def.exec(cliMock, 'stdout', 'something')
+    expect(cliMock.cli.getOutput).toHaveBeenCalledWith('stdout')
+    expect(require('chai').expect).toHaveBeenCalledWith('output')
+    expect(require('chai').contain).toHaveBeenCalledWith('something')
 })
 
 test('should allow to check if stdout or stderr matches a regular expression', () => {
@@ -136,6 +186,12 @@ test('should allow to check if stdout or stderr matches a regular expression', (
     def.shouldNotMatch('stdout should match ')
     def.shouldMatch('stdout should match regex', ['stdout', 'regex'])
     def.shouldMatch('stderr should match regex', ['stderr', 'regex'])
+
+    const cliMock = { cli: { getOutput: jest.fn(() => 'output') } }
+    def.exec(cliMock, 'stdout', 'something')
+    expect(cliMock.cli.getOutput).toHaveBeenCalledWith('stdout')
+    expect(require('chai').expect).toHaveBeenCalledWith('output')
+    expect(require('chai').match).toHaveBeenCalledWith(/something/gim)
 })
 
 test('should allow to check if stdout or stderr does not match a regular expression', () => {
@@ -147,4 +203,10 @@ test('should allow to check if stdout or stderr does not match a regular express
     def.shouldNotMatch('stdout should not match ')
     def.shouldMatch('stdout should not match regex', ['stdout', 'regex'])
     def.shouldMatch('stderr should not match regex', ['stderr', 'regex'])
+
+    const cliMock = { cli: { getOutput: jest.fn(() => 'output') } }
+    def.exec(cliMock, 'stdout', 'something')
+    expect(cliMock.cli.getOutput).toHaveBeenCalledWith('stdout')
+    expect(require('chai').expect).toHaveBeenCalledWith('output')
+    expect(require('chai').match).toHaveBeenCalledWith(/something/gim)
 })

--- a/tests/extensions/cli/definitions.test.js
+++ b/tests/extensions/cli/definitions.test.js
@@ -1,0 +1,150 @@
+'use strict'
+
+const helper = require('../definitions_helper')
+const definitions = require('../../../src/extensions/cli/definitions')
+
+test('should allow to set current working directory', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('set (?:working directory|cwd) to')
+    def.shouldHaveType('Given')
+    def.shouldNotMatch('I set working directory to ')
+    def.shouldMatch('I set working directory to path', ['path'])
+    def.shouldMatch('I set cwd to path', ['path'])
+    def.shouldMatch('set working directory to path', ['path'])
+    def.shouldMatch('set cwd to path', ['path'])
+})
+
+test('should allow to set environment variables', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('set (?:env|environment) (?:vars|variables)')
+    def.shouldHaveType('Given')
+    def.shouldMatch('I set environment variables')
+    def.shouldMatch('I set environment vars')
+    def.shouldMatch('I set env variables')
+    def.shouldMatch('I set env vars')
+    def.shouldMatch('set environment variables')
+    def.shouldMatch('set environment vars')
+    def.shouldMatch('set env variables')
+    def.shouldMatch('set env vars')
+})
+
+test('should allow to set a single environment variable', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('(?:env|environment) (?:var|variable)')
+    def.shouldHaveType('Given')
+    def.shouldNotMatch('I set Accept env var to ')
+    def.shouldNotMatch('I set X User Id env var to 1')
+    def.shouldMatch('I set Accept environment variable to application/json')
+    def.shouldMatch('I set Accept environment var to application/json')
+    def.shouldMatch('I set Accept env variable to application/json')
+    def.shouldMatch('I set Accept env var to application/json')
+    def.shouldMatch('set Accept environment variable to application/json')
+    def.shouldMatch('set Accept environment var to application/json')
+    def.shouldMatch('set Accept env variable to application/json')
+    def.shouldMatch('set Accept env var to application/json')
+})
+
+test('should allow to schedule process killing', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('kill the process with')
+    def.shouldHaveType('Given')
+    def.shouldNotMatch('I kill the process with sig in ')
+    def.shouldNotMatch('I kill the process with sig in 1mn')
+    def.shouldNotMatch('I kill the process with sig in xs')
+    def.shouldMatch('I kill the process with sig in 1s', ['sig', '1', 's'])
+    def.shouldMatch('I kill the process with sig in 10ms', ['sig', '10', 'ms'])
+    def.shouldMatch('kill the process with sig in 1s', ['sig', '1', 's'])
+    def.shouldMatch('kill the process with sig in 10ms', ['sig', '10', 'ms'])
+})
+
+test('should allow to run a command', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('run command')
+    def.shouldHaveType('When')
+    def.shouldNotMatch('I run command ')
+    def.shouldMatch('I run command ls -al', ['ls -al'])
+    def.shouldMatch('run command ls -al', ['ls -al'])
+})
+
+test('should allow to dump stdout & stderr for debugging purpose', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('dump (stderr|stdout)')
+    def.shouldHaveType('When')
+    def.shouldNotMatch('I dump stdcrap')
+    def.shouldMatch('I dump stdout', ['stdout'])
+    def.shouldMatch('I dump stderr', ['stderr'])
+    def.shouldMatch('dump stdout', ['stdout'])
+    def.shouldMatch('dump stderr', ['stderr'])
+})
+
+test('should allow to check exit code', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('(?:command )?exit code should be')
+    def.shouldHaveType('Then')
+    def.shouldNotMatch('the command exit code should be ')
+    def.shouldNotMatch('the command exit code should be nan')
+    def.shouldMatch('the command exit code should be 1', ['1'])
+    def.shouldMatch('command exit code should be 0', ['0'])
+    def.shouldMatch('exit code should be 32', ['32'])
+})
+
+test('should allow to check if stdout or stderr is empty', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('(stderr|stdout) should be empty')
+    def.shouldHaveType('Then')
+    def.shouldNotMatch('stdcrap should be empty')
+    def.shouldMatch('stdout should be empty', ['stdout'])
+    def.shouldMatch('stderr should be empty', ['stderr'])
+})
+
+test('should allow to check if stdout or stderr contains something', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('(stderr|stdout) should contain')
+    def.shouldHaveType('Then')
+    def.shouldNotMatch('stdcrap should contain something')
+    def.shouldNotMatch('stdout should contain ')
+    def.shouldMatch('stdout should contain something', ['stdout', 'something'])
+    def.shouldMatch('stderr should contain something', ['stderr', 'something'])
+})
+
+test('should allow to check if stdout or stderr does not contain something', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('(stderr|stdout) should not contain')
+    def.shouldHaveType('Then')
+    def.shouldNotMatch('stdcrap should not contain something')
+    def.shouldNotMatch('stdout should not contain ')
+    def.shouldMatch('stdout should not contain something', ['stdout', 'something'])
+    def.shouldMatch('stderr should not contain something', ['stderr', 'something'])
+})
+
+test('should allow to check if stdout or stderr matches a regular expression', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('(stderr|stdout) should match')
+    def.shouldHaveType('Then')
+    def.shouldNotMatch('stdcrap should match something')
+    def.shouldNotMatch('stdout should match ')
+    def.shouldMatch('stdout should match regex', ['stdout', 'regex'])
+    def.shouldMatch('stderr should match regex', ['stderr', 'regex'])
+})
+
+test('should allow to check if stdout or stderr does not match a regular expression', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('(stderr|stdout) should not match')
+    def.shouldHaveType('Then')
+    def.shouldNotMatch('stdcrap should not match regex')
+    def.shouldNotMatch('stdout should not match ')
+    def.shouldMatch('stdout should not match regex', ['stdout', 'regex'])
+    def.shouldMatch('stderr should not match regex', ['stderr', 'regex'])
+})

--- a/tests/extensions/definitions_helper.js
+++ b/tests/extensions/definitions_helper.js
@@ -47,6 +47,17 @@ const defShouldNotMatch = (regex, str) => {
     expect(str).not.toMatch(regex)
 }
 
+/**
+ * Executes step definition logic.
+ *
+ * @param {Function} execFn      - Step definition logic
+ * @param {Object}   thisContext - `this` context to emulate cucumber context
+ * @param args
+ */
+const execDef = (execFn, thisContext, ...args) => {
+    execFn.bind(thisContext)(...args)
+}
+
 exports.define = definitions => {
     const mocks = {
         Given: jest.fn(),
@@ -60,7 +71,7 @@ exports.define = definitions => {
         const typeDefs = mocks[type].mock.calls.map(def => ({
             type,
             matcher: def[0], // The step definition regex
-            exec: def[1], // The step definition logic
+            exec: _.partial(execDef, def[1]), // The step definition logic
             shouldHaveType: _.partial(defShouldHaveType, type),
             shouldMatch: _.partial(defShouldMatch, def[0]),
             shouldNotMatch: _.partial(defShouldNotMatch, def[0])

--- a/tests/extensions/definitions_helper.js
+++ b/tests/extensions/definitions_helper.js
@@ -1,0 +1,95 @@
+'use strict'
+
+const _ = require('lodash')
+
+/**
+ * Available definition step types.
+ *
+ * @type {Array.<string>}
+ */
+const definitionTypes = ['Given', 'When', 'Then']
+
+/**
+ * Ensure step definition has the expected type
+ *
+ * @see definitionTypes
+ *
+ * @param {string} expectedType - Expected type
+ * @param {string} type         - Current step definition type
+ */
+const defShouldHaveType = (expectedType, type) => {
+    expect(type).toBe(expectedType)
+}
+
+/**
+ * Tests a step definition against given string.
+ *
+ * @param {RegExp}         regex             - RegExp used to match the step definition
+ * @param {string}         str               - String to test
+ * @param {Array.<string>} [expectedArgs=[]] - Ordered expected arguments
+ */
+const defShouldMatch = (regex, str, expectedArgs = []) => {
+    const matches = str.match(regex)
+
+    expect(matches).not.toBeNull()
+    expectedArgs.forEach((expectedArg, index) => {
+        expect(matches[index + 1]).toBe(expectedArg)
+    })
+}
+
+/**
+ * Ensures a step definition does not match given string.
+ *
+ * @param {RegExp} regex - RegExp used to match the step definition
+ * @param {string} str   - String to test
+ */
+const defShouldNotMatch = (regex, str) => {
+    expect(str).not.toMatch(regex)
+}
+
+exports.define = definitions => {
+    const mocks = {
+        Given: jest.fn(),
+        When: jest.fn(),
+        Then: jest.fn()
+    }
+
+    definitions(mocks)
+
+    const registeredDefinitions = definitionTypes.reduce((acc, type) => {
+        const typeDefs = mocks[type].mock.calls.map(def => ({
+            type,
+            matcher: def[0], // The step definition regex
+            exec: def[1], // The step definition logic
+            shouldHaveType: _.partial(defShouldHaveType, type),
+            shouldMatch: _.partial(defShouldMatch, def[0]),
+            shouldNotMatch: _.partial(defShouldNotMatch, def[0])
+        }))
+
+        return [...acc, ...typeDefs]
+    }, [])
+
+    const matchers = registeredDefinitions.map(({ matcher }) => matcher.toString())
+
+    return {
+        definitions: registeredDefinitions,
+        getDefinitionByMatcher: pattern => {
+            const found = registeredDefinitions.filter(({ matcher }) => matcher.toString().includes(pattern))
+            if (found.length === 0) {
+                throw new TypeError(
+                    `No definition found for pattern: '${pattern}', available definition matchers:\n  - ${matchers.join('\n  - ')}`
+                )
+            }
+
+            if (found.length > 1) {
+                throw new TypeError(
+                    `Pattern '${pattern}' is ambiguous, found ${found.length} definitions:\n  - ${found
+                        .map(({ matcher }) => matcher.toString())
+                        .join('\n  - ')}`
+                )
+            }
+
+            return found[0]
+        }
+    }
+}

--- a/tests/extensions/http_api/definitions.test.js
+++ b/tests/extensions/http_api/definitions.test.js
@@ -3,6 +3,10 @@
 const helper = require('../definitions_helper')
 const definitions = require('../../../src/extensions/http_api/definitions')()
 
+beforeEach(() => {
+    require('chai').clear()
+})
+
 test('should allow to set request headers', () => {
     const context = helper.define(definitions)
 
@@ -10,6 +14,17 @@ test('should allow to set request headers', () => {
     def.shouldHaveType('Given')
     def.shouldMatch('I set request headers')
     def.shouldMatch('set request headers')
+
+    const clientMock = {
+        httpApiClient: { setHeaders: jest.fn() },
+        state: { populateObject: o => o }
+    }
+    const headers = {
+        Accept: 'application/json',
+        'User-Agent': 'veggies/1.0'
+    }
+    def.exec(clientMock, { rowsHash: () => headers })
+    expect(clientMock.httpApiClient.setHeaders).toHaveBeenCalledWith(headers)
 })
 
 test('should allow to set a single request header', () => {
@@ -20,6 +35,13 @@ test('should allow to set a single request header', () => {
     def.shouldNotMatch('I set Accept request header to ')
     def.shouldMatch('I set Accept request header to test', ['Accept', 'test'])
     def.shouldMatch('set Accept request header to test', ['Accept', 'test'])
+
+    const clientMock = {
+        httpApiClient: { setHeader: jest.fn() },
+        state: { populate: v => v }
+    }
+    def.exec(clientMock, 'Accept', 'test')
+    expect(clientMock.httpApiClient.setHeader).toHaveBeenCalledWith('Accept', 'test')
 })
 
 test('should allow to set request json body', () => {
@@ -47,6 +69,17 @@ test('should allow to set request query', () => {
     def.shouldHaveType('Given')
     def.shouldMatch('I set request query')
     def.shouldMatch('set request query')
+
+    const clientMock = {
+        httpApiClient: { setQuery: jest.fn() },
+        state: { populateObject: o => o }
+    }
+    const query = {
+        is_active: 'true',
+        id: '2'
+    }
+    def.exec(clientMock, { rowsHash: () => query })
+    expect(clientMock.httpApiClient.setQuery).toHaveBeenCalledWith(query)
 })
 
 test('should allow to pick response json property', () => {
@@ -66,6 +99,10 @@ test('should allow to reset http client', () => {
     def.shouldHaveType('When')
     def.shouldMatch('I reset http client')
     def.shouldMatch('reset http client')
+
+    const clientMock = { httpApiClient: { reset: jest.fn() } }
+    def.exec(clientMock)
+    expect(clientMock.httpApiClient.reset).toHaveBeenCalled()
 })
 
 test('should allow to perform a request', () => {
@@ -91,6 +128,10 @@ test('should allow to dump response body', () => {
     def.shouldHaveType('When')
     def.shouldMatch('I dump response body')
     def.shouldMatch('dump response body')
+
+    const clientMock = { httpApiClient: { getResponse: jest.fn(() => ({ body: '' })) } }
+    def.exec(clientMock)
+    expect(clientMock.httpApiClient.getResponse).toHaveBeenCalled()
 })
 
 test('should allow to check response HTTP status code', () => {
@@ -104,6 +145,11 @@ test('should allow to check response HTTP status code', () => {
     def.shouldMatch('I should receive a 404 HTTP status code', ['404'])
     def.shouldMatch('should receive a 200 HTTP status code', ['200'])
     def.shouldMatch('should receive a 404 HTTP status code', ['404'])
+
+    const clientMock = { httpApiClient: { getResponse: jest.fn(() => ({ statusCode: 200 })) } }
+    def.exec(clientMock, '200')
+    expect(clientMock.httpApiClient.getResponse).toHaveBeenCalled()
+    expect(require('chai').expect).toHaveBeenCalledWith(200)
 })
 
 test('should allow to check json response', () => {

--- a/tests/extensions/http_api/definitions.test.js
+++ b/tests/extensions/http_api/definitions.test.js
@@ -1,0 +1,131 @@
+'use strict'
+
+const helper = require('../definitions_helper')
+const definitions = require('../../../src/extensions/http_api/definitions')()
+
+test('should allow to set request headers', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('set request headers')
+    def.shouldHaveType('Given')
+    def.shouldMatch('I set request headers')
+    def.shouldMatch('set request headers')
+})
+
+test('should allow to set a single request header', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('request header to')
+    def.shouldHaveType('Given')
+    def.shouldNotMatch('I set Accept request header to ')
+    def.shouldMatch('I set Accept request header to test', ['Accept', 'test'])
+    def.shouldMatch('set Accept request header to test', ['Accept', 'test'])
+})
+
+test('should allow to set request json body', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('set request json body')
+    def.shouldHaveType('Given')
+    def.shouldMatch('I set request json body')
+    def.shouldMatch('set request json body')
+})
+
+test('should allow to set request form body', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('set request form body')
+    def.shouldHaveType('Given')
+    def.shouldMatch('I set request form body')
+    def.shouldMatch('set request form body')
+})
+
+test('should allow to set request query', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('set request query')
+    def.shouldHaveType('Given')
+    def.shouldMatch('I set request query')
+    def.shouldMatch('set request query')
+})
+
+test('should allow to pick response json property', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('pick response json')
+    def.shouldHaveType('Given')
+    def.shouldNotMatch('I pick response json  as ')
+    def.shouldMatch('I pick response json key as value', ['key', 'value'])
+    def.shouldMatch('pick response json key as value', ['key', 'value'])
+})
+
+test('should allow to reset http client', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('reset http client')
+    def.shouldHaveType('When')
+    def.shouldMatch('I reset http client')
+    def.shouldMatch('reset http client')
+})
+
+test('should allow to perform a request', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('GET|POST|PUT|DELETE')
+    def.shouldHaveType('When')
+    def.shouldNotMatch('I GET ')
+    def.shouldMatch('I GET /', ['GET', '/'])
+    def.shouldMatch('I POST /create', ['POST', '/create'])
+    def.shouldMatch('I PUT /update', ['PUT', '/update'])
+    def.shouldMatch('I DELETE /delete', ['DELETE', '/delete'])
+    def.shouldMatch('GET /', ['GET', '/'])
+    def.shouldMatch('POST /create', ['POST', '/create'])
+    def.shouldMatch('PUT /update', ['PUT', '/update'])
+    def.shouldMatch('DELETE /delete', ['DELETE', '/delete'])
+})
+
+test('should allow to dump response body', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('dump response body')
+    def.shouldHaveType('When')
+    def.shouldMatch('I dump response body')
+    def.shouldMatch('dump response body')
+})
+
+test('should allow to check response HTTP status code', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('HTTP status code')
+    def.shouldHaveType('Then')
+    def.shouldNotMatch('I should receive a crap HTTP status code')
+    def.shouldNotMatch('I should receive a 600 HTTP status code')
+    def.shouldMatch('I should receive a 200 HTTP status code', ['200'])
+    def.shouldMatch('I should receive a 404 HTTP status code', ['404'])
+    def.shouldMatch('should receive a 200 HTTP status code', ['200'])
+    def.shouldMatch('should receive a 404 HTTP status code', ['404'])
+})
+
+test('should allow to check json response', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('should receive a json response')
+    def.shouldHaveType('Then')
+    def.shouldMatch('I should receive a json response matching', [undefined])
+    def.shouldMatch('I should receive a json response fully matching', ['fully '])
+    def.shouldMatch('should receive a json response matching', [undefined])
+    def.shouldMatch('should receive a json response fully matching', ['fully '])
+})
+
+test('should allow to check json collection size for a given path', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('should receive a collection of')
+    def.shouldHaveType('Then')
+    def.shouldNotMatch('I should receive a collection of x items for path whatever')
+    def.shouldNotMatch('I should receive a collection of 2 items for path ')
+    def.shouldMatch('I should receive a collection of 1 item for path property', ['1', 'property'])
+    def.shouldMatch('I should receive a collection of 2 items for path property', ['2', 'property'])
+    def.shouldMatch('should receive a collection of 1 item for path property', ['1', 'property'])
+    def.shouldMatch('should receive a collection of 2 items for path property', ['2', 'property'])
+})

--- a/tests/extensions/state/definitions.test.js
+++ b/tests/extensions/state/definitions.test.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const helper = require('../definitions_helper')
+const definitions = require('../../../src/extensions/state/definitions')
+
+test('should allow to set a state property', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('set state (.+) to')
+    def.shouldHaveType('Given')
+    def.shouldNotMatch('I set state property to ')
+    def.shouldMatch('I set state property to value', ['property', 'value'])
+    def.shouldMatch('set state property to value', ['property', 'value'])
+})
+
+test('should allow to clear state', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('clear state')
+    def.shouldHaveType('When')
+    def.shouldMatch('I clear state')
+    def.shouldMatch('clear state')
+})
+
+test('should allow to dump current state', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('dump state')
+    def.shouldHaveType('When')
+    def.shouldMatch('I dump state')
+    def.shouldMatch('dump state')
+})

--- a/tests/extensions/state/definitions.test.js
+++ b/tests/extensions/state/definitions.test.js
@@ -11,6 +11,10 @@ test('should allow to set a state property', () => {
     def.shouldNotMatch('I set state property to ')
     def.shouldMatch('I set state property to value', ['property', 'value'])
     def.shouldMatch('set state property to value', ['property', 'value'])
+
+    const stateMock = { state: { set: jest.fn() } }
+    def.exec(stateMock, 'property', 'value')
+    expect(stateMock.state.set).toHaveBeenCalledWith('property', 'value')
 })
 
 test('should allow to clear state', () => {
@@ -20,6 +24,10 @@ test('should allow to clear state', () => {
     def.shouldHaveType('When')
     def.shouldMatch('I clear state')
     def.shouldMatch('clear state')
+
+    const stateMock = { state: { clear: jest.fn() } }
+    def.exec(stateMock)
+    expect(stateMock.state.clear).toHaveBeenCalled()
 })
 
 test('should allow to dump current state', () => {
@@ -29,4 +37,8 @@ test('should allow to dump current state', () => {
     def.shouldHaveType('When')
     def.shouldMatch('I dump state')
     def.shouldMatch('dump state')
+
+    const stateMock = { state: { dump: jest.fn(() => 'state') } }
+    def.exec(stateMock)
+    expect(stateMock.state.dump).toHaveBeenCalled()
 })

--- a/tests/helper.test.js
+++ b/tests/helper.test.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const Helper = require('../src/helper')
+
+test('should register an extension', () => {
+    const world = {}
+    Helper.registerExtension(world, 'test')
+
+    expect(world).toHaveProperty('_registredExtensions', ['test'])
+})
+
+test('should allow to check if an extension were registered', () => {
+    expect(Helper.hasExtension({}, 'test')).toBe(false)
+    expect(Helper.hasExtension({ _registredExtensions: [] }, 'test')).toBe(false)
+    expect(Helper.hasExtension({ _registredExtensions: ['test'] }, 'test')).toBe(true)
+})
+
+test('should allow to count object properties', () => {
+    expect(
+        Helper.countNestedProperties({
+            a: true,
+            b: true,
+            c: true
+        })
+    ).toBe(3)
+
+    expect(
+        Helper.countNestedProperties({
+            a: true,
+            b: true,
+            c: true,
+            d: {
+                a: true,
+                b: true
+            }
+        })
+    ).toBe(5)
+})


### PR DESCRIPTION
- straighten step definitions:
  - replace `.*` with `.+` when something is required
  - add missing `$`
- CLI
  - remove the `(?:the )?(?:command )?` part from assertion regexp as `(stdout|stderr)` is clear enough
- add `definitions_helper` to ease testing of extensions' step definitions
- globally mock `chai` in jest `tests`