### PR TITLE
Add features for checking response

### DIFF
--- a/src/extensions/http_api/definitions.js
+++ b/src/extensions/http_api/definitions.js
@@ -127,7 +127,7 @@ module.exports = ({ baseUrl = '' } = {}) => ({ Given, When, Then }) => {
                     break
                 case 'equals':
                 default:
-                    expect(_.get(body, propertyMatcher.field)).to.be.equal(expectedValue)
+                    expect(_.get(body, propertyMatcher.field)).to.be.deep.equal(expectedValue)
             }
         })
 

--- a/src/extensions/http_api/definitions.js
+++ b/src/extensions/http_api/definitions.js
@@ -141,9 +141,9 @@ module.exports = ({ baseUrl = '' } = {}) => ({ Given, When, Then }) => {
     /**
      * This definition verify that an array for a given path has the expected length
      */
-    Then(/^(?:I )?should receive a collection of ([0-9]+) items? for path (.+)$/, function(itemsNumber, path) {
+    Then(/^(?:I )?should receive a collection of ([0-9]+) items?(?: for path )?(.+)?$/, function(itemsNumber, path) {
         const { body } = this.httpApiClient.getResponse()
-        const array = _.get(body, path)
+        const array = path !== undefined ? _.get(body, path) : body
 
         expect(array.length).to.be.equal(Number(itemsNumber))
     })

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const _ = require('lodash')
+
 /**
  * Count object properties including nested objects ones.
  * If a property is an object, its key is ignored.

--- a/src/helper.js
+++ b/src/helper.js
@@ -29,7 +29,7 @@ const _ = require('lodash')
 exports.countNestedProperties = object => {
     let propertiesCount = 0
     Object.keys(object).forEach(key => {
-        if (object[key] != null && typeof object[key] === 'object') {
+        if (!_.isEmpty(object[key]) && typeof object[key] === 'object') {
             const count = exports.countNestedProperties(object[key])
             propertiesCount += count
         } else {

--- a/tests/extensions/http_api/definitions.test.js
+++ b/tests/extensions/http_api/definitions.test.js
@@ -221,11 +221,10 @@ test('check json collection size for a given path', () => {
     const def = context.getDefinitionByMatcher('should receive a collection of')
     def.shouldHaveType('Then')
     def.shouldNotMatch('I should receive a collection of x items for path whatever')
-    def.shouldNotMatch('I should receive a collection of 2 items for path ')
     def.shouldMatch('I should receive a collection of 1 item for path property', ['1', 'property'])
     def.shouldMatch('I should receive a collection of 2 items for path property', ['2', 'property'])
     def.shouldMatch('should receive a collection of 1 item for path property', ['1', 'property'])
-    def.shouldMatch('should receive a collection of 2 items for path property', ['2', 'property'])
+    def.shouldMatch('should receive a collection of 2 items', ['2', undefined])
 })
 
 test('match snapshot', () => {

--- a/tests/helper.test.js
+++ b/tests/helper.test.js
@@ -36,3 +36,49 @@ test('should allow to count object properties', () => {
         })
     ).toBe(5)
 })
+
+test('should allow to count nested objects properties', () => {
+    expect(
+        Helper.countNestedProperties({
+            a: true,
+            b: true,
+            c: {
+                d: 'value1',
+                e: 'value2'
+            }
+        })
+    ).toBe(4)
+})
+
+test('should allow to count object properties with null, undefined properties ', () => {
+    expect(
+        Helper.countNestedProperties({
+            a: null,
+            b: undefined,
+            c: 'value3'
+        })
+    ).toBe(3)
+})
+
+test('should allow to count object with properties array property', () => {
+    expect(
+        Helper.countNestedProperties({
+            a: [1, 2],
+            b: true,
+            c: true
+        })
+    ).toBe(4)
+})
+
+test('should allow to count object properties with empty array property', () => {
+    expect(
+        Helper.countNestedProperties({
+            a: true,
+            b: true,
+            c: {
+                d: '',
+                e: []
+            }
+        })
+    ).toBe(4)
+})


### PR DESCRIPTION
In this MR : 
- When getting object property with path, you can now use '.' for referencing root object.
- Empty array is now handled when counting object properties
- When checking response, we now do a 'deepEqual' for checking correctly array.