### PR TITLE
fix(readMe): fix status code verification step in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ for the [dedicated extension](#http-api-extension).
 Scenario: Using GitHub API
   Given I set User-Agent request header to veggies/1.0
   When I GET https://api.github.com/
-  Then I should receive a 200 HTTP status code
+  Then response status code should be 200
 ```
 
 #### Posting data
@@ -112,7 +112,7 @@ Scenario: Creating a resource using json payload
     | username | plouc |
     | gender   | male  |
   When I POST https://my-api.io/users
-  Then I should receive a 201 HTTP status code
+  Then response status code should be 200
 ```
 
 You can also use form encoded values, all you have to do is
@@ -124,7 +124,7 @@ Scenario: Creating a resource using json payload
     | username | plouc |
     | gender   | male  |
   When I POST https://my-api.io/users
-  Then I should receive a 201 HTTP status code
+  Then response status code should be 200
 ```
 
 #### Posting data using fixture file
@@ -145,7 +145,7 @@ gender:   male
 Scenario: Creating a resource using json payload
   Given I set request form body from user
   When I POST https://my-api.io/users
-  Then I should receive a 201 HTTP status code
+  Then response status code should be 200
 ```
 
 #### Using values issued by a previous request
@@ -171,7 +171,7 @@ Scenario: Using GitHub API
   When I GET https://api.github.com/
   And I pick response json emojis_url as emojisUrl
   And I GET {{emojisUrl}}
-  Then I should receive a 200 HTTP status code
+  Then response status code should be 200
 ```
 
 It's even possible to mix this approach with scenario outline to have more concise tests
@@ -184,10 +184,10 @@ using different response values for second request.
 Scenario Outline: Fetching <key> API endpoint from root endpoint
   Given I set User-Agent request header to veggies/1.0
   When I GET https://api.github.com/
-  Then I should receive a 200 HTTP status code
+  Then response status code should be 200
   When I pick response json <key> as <key>
   And I GET {{<key>}}
-  Then I should receive a 200 HTTP status code
+  Then response status code should be 200
 
   Examples:
     | key              |
@@ -352,7 +352,7 @@ Scenario: Creating a resource using typed json payload
     | is_active | true((boolean))          |
     | hobbies   | drawing,hacking((array)) |
   When I POST https://my-api.io/users
-  Then I should receive a 201 HTTP status code
+  Then response status code should be 200
 ```
 
 which will generate the following payload:


### PR DESCRIPTION
The step definition used in the README to verify a HTTP status code was not the correct one