### PR TITLE
Add step for adding request headers without modifying already set ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,7 @@ httpApi.install({
 ```yaml    
 Given:
   - /^(?:I )?set request headers$/
+  - /^(?:I )?assign request headers$/
   - /^(?:I )?set ([a-zA-Z0-9-]+) request header to (.+)$/
   - /^(?:I )?clear request headers/
   - /^(?:I )?set request json body$/

--- a/src/extensions/http_api/definitions.js
+++ b/src/extensions/http_api/definitions.js
@@ -30,6 +30,16 @@ module.exports = ({ baseUrl = '' } = {}) => ({ Given, When, Then }) => {
     })
 
     /**
+     * Assign http headers
+     * The difference from "set request headers" is that "set" set the whole headers object
+     * "assign" replace or set the given headers, keeping untouched the ones already set 
+     */
+    Given(/^(?:I )?assign request headers$/, function(step) {
+        const headers = Cast.object(this.state.populateObject(step.rowsHash()))
+        _.each(headers, (value, key) => this.httpApiClient.setHeader(key, value))
+    })
+
+    /**
      * Setting a single http header
      */
     Given(/^(?:I )?set ([a-zA-Z0-9-]+) request header to (.+)$/, function(key, value) {

--- a/tests/extensions/http_api/definitions.test.js
+++ b/tests/extensions/http_api/definitions.test.js
@@ -27,6 +27,28 @@ test('set request headers', () => {
     expect(clientMock.httpApiClient.setHeaders).toHaveBeenCalledWith(headers)
 })
 
+test('assign request headers', () => {
+    const context = helper.define(definitions)
+
+    const def = context.getDefinitionByMatcher('assign request headers')
+    def.shouldHaveType('Given')
+    def.shouldMatch('I assign request headers')
+    def.shouldMatch('assign request headers')
+
+    const clientMock = {
+        httpApiClient: { setHeader: jest.fn() },
+        state: { populateObject: o => o }
+    }
+    const headers = {
+        Accept: 'application/json',
+        'User-Agent': 'veggies/1.0'
+    }
+    def.exec(clientMock, { rowsHash: () => headers })
+    expect(clientMock.httpApiClient.setHeader).toHaveBeenCalledTimes(2)
+    expect(clientMock.httpApiClient.setHeader).toHaveBeenCalledWith('Accept', 'application/json')
+    expect(clientMock.httpApiClient.setHeader).toHaveBeenCalledWith('User-Agent', 'veggies/1.0')
+})
+
 test('set a single request header', () => {
     const context = helper.define(definitions)
 


### PR DESCRIPTION
**Summary**

Adding a new definition "I assign request headers" in order to add multiple headers and keeping previous ones that might be already set.

**Test plan**

When calling step "I assign request headers", i assume we only call the "setHeader" for all headers described in scenario. 
