### PR TITLE
feat(snapshot): add snapshot support for Scenario Outline

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It's also the perfect companion for testing CLI applications built with commande
     - [**http API**](#http-api-extension) [install](#http-api-installation) | [gherkin expressions](#http-api-gherkin-expressions) | [low level API](#http-api-low-level-api)
     - [**CLI**](#cli-extension) [install](#cli-installation) | [gherkin expressions](#cli-gherkin-expressions) | [low level API](#cli-low-level-api)
     - [**fileSystem**](#file-system-extension) [install](#file-system-installation) | [gherkin expressions](#file-system-gherkin-expressions) | [low level API](#file-system-low-level-api)
-    - [**snapshot**](#snapshot-extension) [install](#snapshot-installation) | [low level API](#snapshot-low-level-api)
+    - [**snapshot**](#snapshot-extension) [install](#snapshot-extension-installation) | [low level API](#snapshot-low-level-api)
 - [Helpers](#helpers)
     - [**cast**](#cast-helper) [usage](#cast-usage) | [add a type](#add-a-type)
 - [Examples](#examples)   

--- a/examples/features/snapshot/__snapshots__/snapshot.feature.snap
+++ b/examples/features/snapshot/__snapshots__/snapshot.feature.snap
@@ -1,5 +1,13 @@
 
 
+exports[`Scenario Outline 1.1`] = `undefined`;
+
+exports[`Scenario Outline 2.1`] = `undefined`;
+
+exports[`Scenario Outline 3.1`] = `undefined`;
+
+exports[`Scenario Outline 4.1`] = `undefined`;
+
 exports[`Setting json body from .yaml fixture file 1.1`] = `Object {
   "first_name": "Raphaël",
   "gender": "male",
@@ -18,6 +26,12 @@ exports[`Snapshot testing on cli 1.1`] = `"test
 "`;
 
 exports[`Snapshot testing on files 1.1`] = `"id:         1
+first_name: Raphaël
+last_name:  Benitte
+gender:     male
+"`;
+
+exports[`Snapshot testing on files 2.1`] = `"id:         1
 first_name: Raphaël
 last_name:  Benitte
 gender:     male

--- a/examples/features/snapshot/snapshot.feature
+++ b/examples/features/snapshot/snapshot.feature
@@ -15,3 +15,23 @@ Feature: Using snapshot definitions
     Scenario: Snapshot testing on files
         Given I set cwd to examples/features/snapshot/fixtures
         Then file file.yaml should match snapshot
+
+    Scenario Outline: I get all posts filtered using '<filter>=<value>' directive
+        Given I mock http call to forward request body for path /users/yaml
+        When I POST http://fake.io/users/yaml
+        Then response status code should be 200
+        And response body should match snapshot
+
+        Examples:
+            | filter       | value          |
+
+            | title        | car industry   |
+
+            | anotherTitle | antother value |
+            # this comment and the empty lines above and below shouldn't be taken into account
+
+
+            | tester       | tesfdkngjsfk   |
+    Scenario: Snapshot testing on files
+        Given I set cwd to examples/features/snapshot/fixtures
+        Then file file.yaml should match snapshot


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
The two fields below are mandatory.
-->

**Summary**
This PR is in response to https://github.com/ekino/veggies/issues/24 
I try to make the snapshot support `Scenario Outlines`

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
The snapshots developed by @bnadim didn't work with Scenario Outlines, @plouc pointed that out, and I tried to solve the problem as best as I can. I am still willing to refine my code until this PR's is acceptable and merged :) 

**Test plan**
To test this, I added one test to `examples/filters/snapshot/snapshot.feature` which is a Scenario Outline where the examples are somewhat scattered across multiple lines, so as to test that the blank lines and comments are ignored. 
To run my tests, I used this command `cucumberjs --require examples/support examples/features --tags @snapshot`