### PR TITLE
feat(http-api): accept a body for DELETE request

### DIFF
--- a/src/extensions/http_api/client.js
+++ b/src/extensions/http_api/client.js
@@ -14,6 +14,8 @@ const BODY_TYPE_JSON = 'json'
 const BODY_TYPE_FORM = 'form'
 const BODY_TYPE_MULTIPART = 'form-data'
 
+const verbsAcceptingBody = ['POST', 'PUT', 'DELETE']
+
 /**
  * Http Api Client extension.
  *
@@ -230,9 +232,11 @@ class HttpApiClient {
             const fullUri = `${baseUrl}${path}`
 
             if (this.body !== null) {
-                if (!['POST', 'PUT'].includes(method)) {
+                if (!verbsAcceptingBody.includes(method)) {
                     throw new Error(
-                        `You can only provides a body for POST and PUT HTTP methods, found: ${method}`
+                        `You can only provide a body for ${verbsAcceptingBody.join(
+                            ', '
+                        )} HTTP methods, found: ${method}`
                     )
                 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
The two fields below are mandatory.
-->

**Summary**
Added support for set request json body, when the request has a DELETE http verb.
Having a body with a DELETE request is valid in http. 

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**
No added tests. Please note that the feature that tests that an allowed http verb when having a body is not tested. 