### PR TITLE
fix(snapshot): correct snapshot comparison with carriage returns

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 indent_style = space
 indent_size = 4
 charset = utf-8
-trim_trailing_whitespace = true
+trim_trailing_whitespace = false
 insert_final_newline = true
 
 [*.md]

--- a/README.md
+++ b/README.md
@@ -883,9 +883,9 @@ Then(/^I check something using file system$/, function() {
 
 ### Snapshot extension 
 
-#### Snapshot extension installation
+#### Snapshot installation
 
-The snapshot extension add capabilities to [api](#http-api-extension), [cli](#cli--extension) and [file](#file-system-extension) extensions,
+The snapshot extension add capabilities to [api](#http-api-extension), [cli](#cli-extension) and [file](#file-system-extension) extensions,
 so you will need these extensions if you want to use snapshot related gherkin definitions.
 
 To install the extension, you should add the following snippet
@@ -996,13 +996,13 @@ yarn run examples -- --tags @offline
 
 Due to public API rate limit (eg. GitHub API), this tag is used when running on CI.
 
-[npm-image]: https://img.shields.io/npm/v/@ekino/veggies.svg?style=flat-square
+[npm-image]: https://img.shields.io/npm/v/@ekino/veggies.svg?longCache=true&style=for-the-badge
 [npm-url]: https://www.npmjs.com/package/@ekino/veggies
-[travis-image]: https://img.shields.io/travis/ekino/veggies.svg?style=flat-square
+[travis-image]: https://img.shields.io/travis/ekino/veggies.svg?longCache=true&style=for-the-badge
 [travis-url]: https://travis-ci.org/ekino/veggies
-[prettier-image]: https://img.shields.io/badge/styled_with-prettier-ff69b4.svg?style=flat-square
+[prettier-image]: https://img.shields.io/badge/styled_with-prettier-ff69b4.svg?longCache=true&style=for-the-badge
 [prettier-url]: https://github.com/prettier/prettier
-[coverage-image]: https://img.shields.io/coveralls/ekino/veggies/master.svg?style=flat-square
+[coverage-image]: https://img.shields.io/coveralls/ekino/veggies/master.svg?longCache=true&style=for-the-badge
 [coverage-url]: https://coveralls.io/github/ekino/veggies?branch=master
 
 [github-watch-badge]: https://img.shields.io/github/watchers/ekino/veggies.svg?style=social

--- a/doc/README.tpl.md
+++ b/doc/README.tpl.md
@@ -821,9 +821,9 @@ Then(/^I check something using file system$/, function() {
 
 ### Snapshot extension 
 
-#### Snapshot extension installation
+#### Snapshot installation
 
-The snapshot extension add capabilities to [api](#http-api-extension), [cli](#cli--extension) and [file](#file-system-extension) extensions,
+The snapshot extension add capabilities to [api](#http-api-extension), [cli](#cli-extension) and [file](#file-system-extension) extensions,
 so you will need these extensions if you want to use snapshot related gherkin definitions.
 
 To install the extension, you should add the following snippet
@@ -934,13 +934,13 @@ yarn run examples -- --tags @offline
 
 Due to public API rate limit (eg. GitHub API), this tag is used when running on CI.
 
-[npm-image]: https://img.shields.io/npm/v/@ekino/veggies.svg?style=flat-square
+[npm-image]: https://img.shields.io/npm/v/@ekino/veggies.svg?longCache=true&style=for-the-badge
 [npm-url]: https://www.npmjs.com/package/@ekino/veggies
-[travis-image]: https://img.shields.io/travis/ekino/veggies.svg?style=flat-square
+[travis-image]: https://img.shields.io/travis/ekino/veggies.svg?longCache=true&style=for-the-badge
 [travis-url]: https://travis-ci.org/ekino/veggies
-[prettier-image]: https://img.shields.io/badge/styled_with-prettier-ff69b4.svg?style=flat-square
+[prettier-image]: https://img.shields.io/badge/styled_with-prettier-ff69b4.svg?longCache=true&style=for-the-badge
 [prettier-url]: https://github.com/prettier/prettier
-[coverage-image]: https://img.shields.io/coveralls/ekino/veggies/master.svg?style=flat-square
+[coverage-image]: https://img.shields.io/coveralls/ekino/veggies/master.svg?longCache=true&style=for-the-badge
 [coverage-url]: https://coveralls.io/github/ekino/veggies?branch=master
 
 [github-watch-badge]: https://img.shields.io/github/watchers/ekino/veggies.svg?style=social

--- a/src/extensions/snapshot/extension.js
+++ b/src/extensions/snapshot/extension.js
@@ -71,6 +71,7 @@ class Snapshot {
      */
     expectToMatch(expectedContent) {
         expectedContent = prettyFormat(expectedContent)
+        expectedContent = snapshot.normalizeNewlines(expectedContent)
         let snapshotsFile = snapshot.snapshotsPath(this.featureFile, this.options)
 
         const scenarios = snapshot.extractScenarios(this.featureFile)

--- a/tests/extensions/snapshot/extension.test.js
+++ b/tests/extensions/snapshot/extension.test.js
@@ -23,7 +23,7 @@ beforeAll(() => {
             return fixtures.featureFileContent1
         if (file === fixtures.featureFile1With3SnapshotsInAScenario)
             return fixtures.featureFileContent1
-
+        if (file === fixtures.featureFileMultilineString) return fixtures.featureFileContent1
         if (file === fixtures.snapshotFile1) return fixtures.snapshotFileContent1
         if (file === fixtures.snapshotFile1WithPropertyMatchers)
             return fixtures.snapshotFileContent1WithPropertyMatchers
@@ -32,7 +32,8 @@ beforeAll(() => {
             return fixtures.snapshotFileContent1
         if (file === fixtures.snapshotFile1With3SnapshotsInAScenario)
             return fixtures.snapshotFileContent1With3SnapshotsInAScenario
-
+        if (file === fixtures.snapshotFileMultilineString)
+            return fixtures.snapshotFileContentMultilineString
         throw new Error(`Unexpected call to readFileSync with file ${file}`)
     })
 
@@ -45,6 +46,7 @@ beforeAll(() => {
         if (file === fixtures.snapshotFile1And2) return {}
         if (file === fixtures.snapshotFile1With2SnapshotsInAScenario) return {}
         if (file === fixtures.snapshotFile1With3SnapshotsInAScenario) return {}
+        if (file === fixtures.snapshotFileMultilineString) return {}
         throw new Error(`Unexpected call to statSync with file ${file}`)
     })
 })
@@ -238,4 +240,13 @@ test('expectToMatchJson should throw an error if a property matcher changes', ()
     expect(() => snapshot.expectToMatchJson(fixtures.value1WithError, propertiesMatchers)).toThrow(
         fixtures.diffErrorFile1WithPropertyMatchers
     )
+})
+
+test('expectToMatch should handle multline content correctly', () => {
+    const snapshot = Snapshot({ cleanSnapshots: true })
+
+    snapshot.featureFile = fixtures.featureFileMultilineString
+    snapshot.scenarioLine = 3
+    expect(snapshot.expectToMatch(fixtures.multilineValue)).toBeUndefined()
+    clean.cleanSnapshots()
 })

--- a/tests/extensions/snapshot/fixtures.js
+++ b/tests/extensions/snapshot/fixtures.js
@@ -6,10 +6,10 @@ exports.featureFileContent1 = dedent`
 
         Scenario: scenario 1
             When I do something...
-            
+
         Scenario: scenario 2
             When I do something...
-            
+
         Scenario: scenario 1
             When I do something...
     """
@@ -52,6 +52,19 @@ exports.snapshotContent1WithPropertyMatchers = dedent`
       "key3": "value3",
       "key4": "value4",
       "key5": "value5",
+    }
+`
+
+exports.snapshotContentMultilineString = dedent`
+    Object {
+      "content": Object {
+        "long text": "I
+     am 
+     a
+     long
+     text",
+        "text": "i am a text",
+      },
     }
 `
 
@@ -102,6 +115,12 @@ exports.snapshotFileContent1WithValue2 = `
 exports[\`scenario 1 1.1\`] = \`${exports.snapshotContent2}\`;
 `
 
+exports.snapshotFileContentMultilineString = `
+
+exports[\`scenario 1 1.1\`] = \`${exports.snapshotContentMultilineString}\`;
+
+`
+
 exports.diffErrorValue1VsValue2 = dedent`
     \u001b[32m- Snapshot\u001b[39m
     \u001b[31m+ Received\u001b[39m
@@ -141,6 +160,9 @@ exports.value1WithError = {
 }
 exports.value2 = { key1: 'value1', key2: 'value2', key3: 'value8', key4: 'value4', key5: 'value5' }
 exports.value3 = { key1: 'value1', key2: 'value2', key3: 'value9', key4: 'value4', key5: 'value5' }
+exports.multilineValue = {
+    content: { text: 'i am a text', 'long text': 'I\r\n am \r\n a\r\n long\r\n text' }
+}
 
 exports.featureFile1 = './snapshot1.feature'
 exports.featureFile1WithPropertyMatchers = './snapshot1WithPropertyMatchers.feature'
@@ -148,6 +170,7 @@ exports.featureFile1And2 = './snapshot1And2.feature'
 exports.featureFile1NotExists = './snapshot1NotExists.feature'
 exports.featureFile1With2SnapshotsInAScenario = './snapshot1With2SnapshotsInAScenario.feature'
 exports.featureFile1With3SnapshotsInAScenario = './snapshot1With3SnapshotsInAScenario.feature'
+exports.featureFileMultilineString = './snapshotMultilineString.feature'
 
 exports.snapshotFile1 = '__snapshots__/snapshot1.feature.snap'
 exports.snapshotFile1WithPropertyMatchers =
@@ -158,3 +181,5 @@ exports.snapshotFile1With2SnapshotsInAScenario =
     '__snapshots__/snapshot1With2SnapshotsInAScenario.feature.snap'
 exports.snapshotFile1With3SnapshotsInAScenario =
     '__snapshots__/snapshot1With3SnapshotsInAScenario.feature.snap'
+
+exports.snapshotFileMultilineString = '__snapshots__/snapshotMultilineString.feature.snap'

--- a/yarn.lock
+++ b/yarn.lock
@@ -636,9 +636,9 @@ acorn@^5.5.3:
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
 acorn@^6.0.1:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"
-  integrity sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.0.tgz#b659d2ffbafa24baf5db1cdbb2c94a983ecd2784"
+  integrity sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==
 
 acorn@^7.1.0:
   version "7.1.0"
@@ -879,9 +879,9 @@ aws-sign2@~0.7.0:
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
 aws4@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
-  integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.0.tgz#24390e6ad61386b0a747265754d2a17219de862c"
+  integrity sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==
 
 babel-jest@^24.9.0:
   version "24.9.0"
@@ -1020,11 +1020,6 @@ browser-resolve@^1.11.3:
   integrity sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==
   dependencies:
     resolve "1.1.7"
-
-browser-stdout@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
-  integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
 bser@^2.0.0:
   version "2.1.1"
@@ -1241,14 +1236,6 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
-cobertura-parse@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/cobertura-parse/-/cobertura-parse-1.0.5.tgz#3a8c5d30a97468496a2aabd04b8fa4fb7c3cd20e"
-  integrity sha512-uYJfkGhzw1wibe/8jqqHmSaPNWFguzq/IlSj83u3cSnZho/lUnfj0mLTmZGmB3AiKCOTYr22TYwpR1sXy2JEkg==
-  dependencies:
-    mocha "5.0.5"
-    xml2js "0.4.19"
-
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -1297,11 +1284,6 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
-
-commander@2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
-  integrity sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==
 
 commander@^2.18.0, commander@^2.20.0, commander@^2.8.0, commander@~2.20.3:
   version "2.20.3"
@@ -1399,11 +1381,10 @@ cosmiconfig@^5.2.0, cosmiconfig@^5.2.1:
     parse-json "^4.0.0"
 
 coveralls@3.x:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.8.tgz#3ed8f0ebdcf8a87ff3f9f4bde220b86d998ebe64"
-  integrity sha512-lkQlg29RhV9zwB0gDaEAWoap8xPgFxtPsVIpTNiDDtWNrvtP1/RmGJRRAV/Loz2gihmppObkSL0wnptEGUXaOQ==
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.9.tgz#8cfc5a5525f84884e2948a0bf0f1c0e90aac0420"
+  integrity sha512-nNBg3B1+4iDox5A5zqHKzUTiwl2ey4k2o0NEcVZYvl+GOSJdKBj4AJGKLv6h3SvWch7tABHePAQOSZWM9E2hMg==
   dependencies:
-    cobertura-parse "^1.0.5"
     js-yaml "^3.13.1"
     lcov-parse "^1.0.0"
     log-driver "^1.2.7"
@@ -1530,13 +1511,6 @@ date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
-
-debug@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
 
 debug@^2.1.3, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -1667,7 +1641,7 @@ diff-sequences@^24.9.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
   integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
 
-diff@3.5.0, diff@^3.5.0:
+diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
@@ -1818,7 +1792,7 @@ es6-symbol@^3.1.1, es6-symbol@~3.1.3:
     d "^1.0.1"
     ext "^1.1.2"
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -2417,18 +2391,6 @@ glob@7.1, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
-  integrity sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 global-dirs@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
@@ -2485,11 +2447,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
-growl@1.10.3:
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
-  integrity sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==
-
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -2525,11 +2482,6 @@ has-ansi@^2.0.0:
   integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
   dependencies:
     ansi-regex "^2.0.0"
-
-has-flag@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
-  integrity sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -2588,11 +2540,6 @@ has@^1.0.1, has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
-
-he@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
-  integrity sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
 
 hosted-git-info@^2.1.4:
   version "2.8.5"
@@ -3641,9 +3588,9 @@ linkify-it@^2.0.0:
     uc.micro "^1.0.1"
 
 lint-staged@9.x:
-  version "9.4.3"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-9.4.3.tgz#f55ad5f94f6e105294bfd6499b23142961f7b982"
-  integrity sha512-PejnI+rwOAmKAIO+5UuAZU9gxdej/ovSEOAY34yMfC3OS4Ac82vCBPzAWLReR9zCPOMqeVwQRaZ3bUBpAsaL2Q==
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-9.5.0.tgz#290ec605252af646d9b74d73a0fa118362b05a33"
+  integrity sha512-nawMob9cb/G1J98nb8v3VC/E8rcX1rryUYXVZ69aT9kde6YWX+uvNOEHY5yf2gcWcTJGiD0kqXmCnS3oD75GIA==
   dependencies:
     chalk "^2.4.2"
     commander "^2.20.0"
@@ -4040,28 +3987,12 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
-
-mocha@5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.0.5.tgz#e228e3386b9387a4710007a641f127b00be44b52"
-  integrity sha512-3MM3UjZ5p8EJrYpG7s+29HAI9G7sTzKEe4+w37Dg0QP7qL4XGsV+Q2xet2cE37AqdgN1OtYQB6Vl98YiPV3PgA==
-  dependencies:
-    browser-stdout "1.3.1"
-    commander "2.11.0"
-    debug "3.1.0"
-    diff "3.5.0"
-    escape-string-regexp "1.0.5"
-    glob "7.1.2"
-    growl "1.10.3"
-    he "1.1.1"
-    mkdirp "0.5.1"
-    supports-color "4.4.0"
 
 ms@2.0.0:
   version "2.0.0"
@@ -4988,9 +4919,9 @@ resolve@1.1.7:
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
 resolve@^1.10.0, resolve@^1.3.2, resolve@^1.3.3:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.13.0.tgz#e879eb397efb40511056ede7300b6ac28c51290b"
-  integrity sha512-HHZ3hmOrk5SvybTb18xq4Ek2uLqLO5/goFCYUyvn26nWox4hdlKlfC/+dChIZ6qc4ZeYcN9ekTz0yyHsFgumMw==
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.13.1.tgz#be0aa4c06acd53083505abb35f4d66932ab35d16"
+  integrity sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==
   dependencies:
     path-parse "^1.0.6"
 
@@ -5107,7 +5038,7 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sax@>=0.6.0, sax@^1.2.4:
+sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -5577,13 +5508,6 @@ strip-url-auth@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strip-url-auth/-/strip-url-auth-1.0.1.tgz#22b0fa3a41385b33be3f331551bbb837fa0cd7ae"
   integrity sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=
-
-supports-color@4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
-  integrity sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==
-  dependencies:
-    has-flag "^2.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -6103,19 +6027,6 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
-
-xml2js@0.4.19:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
-  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
-  dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~9.0.1"
-
-xmlbuilder@~9.0.1:
-  version "9.0.7"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
-  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xmlcreate@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
**Summary**

Veggies use a method named ```normalizeNewlines``` on the content before writing the snapshot (and it replace carriage return and line feed (\r\n) with line feed (\n)), . Unfortunately this method is not used on the content when we try to compare it to the previously generated snapshot, and the comparison fail. The change is to apply  
```normalizeNewlines``` on the content in the ```expectToMatch```method from the snapshot extension

**Test plan**

Not sure if i put test in the right place ...  maybe have to change it :) . Add one functional test in the example sections, but there is also functional test in tests folder but only for snapshot extension ( and don't look very relevant). By the way test a content with CR LF and expect the comparison with the snapshot to match
