### PR TITLE
feat(assertions): expose function to assert date with formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,17 @@ Scenario: Fetching some json response from the internets
       | address.country | match   | ^Jap(.+)$ |
 ``` 
 
+Checking json response properties equalRelativeDate value:
+
+```gherkin
+Scenario: Fetching some json response from the internets
+    When I GET http://whatever.io/things/1
+    Then json response should match
+      | field           | matcher            | value                                        |
+      | endDate         | equalRelativeDate  | 2,days,fr,dddd                               |
+      | beginDate       | equalRelativeDate  | -1,week,fr,[Aujourd'hui] YYYY-MM-DD hh[h]mm  |
+``` 
+
 By default this assertion does not check for full match.
 Properties not listed will just be ignored, if you want a full match:
 
@@ -275,17 +286,17 @@ Now if the json contains extra properties, the test will fail.
 
 Available matchers are:
 
-| matcher    | description                       |
-|----------- |---------------------------------- |
-| `match`    | property must match given regexp  |
-| `matches`  | see `match`                       |
-| `contain`  | property must contain given value |
-| `contains` | see `contain`                     |
-| `defined`  | property must not be `undefined`  |
-| `present`  | see `defined`                     |     
-| `equal`    | property must equal given value   |
-| `equals`   | see `equal`                       |     
-
+| matcher                   | description                                       |
+|-------------------------- |---------------------------------------------------|
+| `match`                   | property must match given regexp                  |
+| `matches`                 | see `match`                                       |
+| `contain`                 | property must contain given value                 |
+| `contains`                | see `contain`                                     |
+| `defined`                 | property must not be `undefined`                  |
+| `present`                 | see `defined`                                     |
+| `equal`                   | property must equal given value                   |
+| `equals`                  | see `equal`                                       |
+| `equalRelativeDate`       | property must be equal to the computed date       |
 #### Testing response headers
 
 In order to check response headers, you have the following gherkin expression available:

--- a/doc/README.tpl.md
+++ b/doc/README.tpl.md
@@ -263,6 +263,17 @@ Scenario: Fetching some json response from the internets
       | address.country | match   | ^Jap(.+)$ |
 ``` 
 
+Checking json response properties equalRelativeDate value:
+
+```gherkin
+Scenario: Fetching some json response from the internets
+    When I GET http://whatever.io/things/1
+    Then json response should match
+      | field           | matcher            | value                                        |
+      | endDate         | equalRelativeDate  | 2,days,fr,dddd                               |
+      | beginDate       | equalRelativeDate  | -1,week,fr,[Aujourd'hui] YYYY-MM-DD hh[h]mm  |
+``` 
+
 By default this assertion does not check for full match.
 Properties not listed will just be ignored, if you want a full match:
 
@@ -279,17 +290,17 @@ Now if the json contains extra properties, the test will fail.
 
 Available matchers are:
 
-| matcher    | description                       |
-|----------- |---------------------------------- |
-| `match`    | property must match given regexp  |
-| `matches`  | see `match`                       |
-| `contain`  | property must contain given value |
-| `contains` | see `contain`                     |
-| `defined`  | property must not be `undefined`  |
-| `present`  | see `defined`                     |     
-| `equal`    | property must equal given value   |
-| `equals`   | see `equal`                       |     
-
+| matcher                   | description                                       |
+|-------------------------- |---------------------------------------------------|
+| `match`                   | property must match given regexp                  |
+| `matches`                 | see `match`                                       |
+| `contain`                 | property must contain given value                 |
+| `contains`                | see `contain`                                     |
+| `defined`                 | property must not be `undefined`                  |
+| `present`                 | see `defined`                                     |
+| `equal`                   | property must equal given value                   |
+| `equals`                  | see `equal`                                       |
+| `equalRelativeDate`       | property must be equal to the computed date       |
 #### Testing response headers
 
 In order to check response headers, you have the following gherkin expression available:

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "jest-diff": "24.9",
     "js-yaml": "3.13",
     "lodash": "4.17",
+    "moment-timezone": "^0.5.27",
     "natural-compare": "1.4",
     "pretty-format": "24.9",
     "request": "2.88",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4252,6 +4252,18 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+moment-timezone@^0.5.27:
+  version "0.5.27"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.27.tgz#73adec8139b6fe30452e78f210f27b1f346b8877"
+  integrity sha512-EIKQs7h5sAsjhPCqN6ggx6cEbs94GK050254TIJySD1bzoM5JTYDwAU1IoVOeTOL6Gm27kYJ51/uuvq1kIlrbw==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0":
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
**Goal**

The purpose of this pull request is to be able to validate date field of an api response. 
Given a format, a locale and a offset to now, this value will be compared to a specific field. 

**Summary**

With this pull request, one can target a field in an api response and be able to explicitly validate the field. You will find an example here below of the syntax. 

```
| field    | matcher         | value                                 |
| dateA | equalRelativeDate | 2,days,dddd,fr                         |
| dateB | equalRelativeDate | -1,week,dddd,fr                       |
| dateC | equalRelativeDate | 4,hours,en,[Today] hh[h]mm |
```
