### PR TITLE
feat(http): allow headers with underscores

### DIFF
--- a/src/extensions/http_api/definitions.js
+++ b/src/extensions/http_api/definitions.js
@@ -58,7 +58,7 @@ exports.install = ({ baseUrl = '' } = {}) => {
     /**
      * Setting a single http header
      */
-    Given(/^(?:I )?set ([a-zA-Z0-9-]+) request header to (.+)$/, function (key, value) {
+    Given(/^(?:I )?set ([a-zA-Z0-9-_]+) request header to (.+)$/, function (key, value) {
         this.httpApiClient.setHeader(key, Cast.value(this.state.populate(value)))
     })
 

--- a/tests/extensions/http_api/definitions.test.js
+++ b/tests/extensions/http_api/definitions.test.js
@@ -72,6 +72,36 @@ test('set a single request header', () => {
     expect(clientMock.httpApiClient.setHeader).toHaveBeenCalledWith('Accept', 'test')
 })
 
+test('set a single request header with a dash', () => {
+    const context = helper.getContext() // Extension context
+
+    const def = context.getDefinitionByMatcher('request header to')
+    def.shouldMatch('I set X-Custom request header to test', ['X-Custom', 'test'])
+    def.shouldMatch('set X-Custom request header to test', ['X-Custom', 'test'])
+
+    const clientMock = {
+        httpApiClient: { setHeader: jest.fn() },
+        state: { populate: (v) => v },
+    }
+    def.exec(clientMock, 'X-Custom', 'test')
+    expect(clientMock.httpApiClient.setHeader).toHaveBeenCalledWith('X-Custom', 'test')
+})
+
+test('set a single request header with an underscore', () => {
+    const context = helper.getContext() // Extension context
+
+    const def = context.getDefinitionByMatcher('request header to')
+    def.shouldMatch('I set X_Custom request header to test', ['X_Custom', 'test'])
+    def.shouldMatch('set X_Custom request header to test', ['X_Custom', 'test'])
+
+    const clientMock = {
+        httpApiClient: { setHeader: jest.fn() },
+        state: { populate: (v) => v },
+    }
+    def.exec(clientMock, 'X_Custom', 'test')
+    expect(clientMock.httpApiClient.setHeader).toHaveBeenCalledWith('X_Custom', 'test')
+})
+
 test('clear request headers', () => {
     const context = helper.getContext() // Extension context
 


### PR DESCRIPTION
**Summary**
This PR adds support for adding a header containing underscores.

**Motivation**
A simple enhancement to get familiar with the project.

Closes #17 

**Test plan**
Two tests have been added:
- set a single request header with a dash
- set a single request header with an underscore
