### PR TITLE
feat(snapshots): add a flag to prevent snapshots creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,9 @@ In case you need to remove unused snapshots, you can use the option `--cleanSnap
 :warning: You shouldn't use this option with tags. It may result in used snapshots removed.
 :information_source: Snapshot files related to feature files with no snapshots anymore won't get removed. You need to do it manually.
 
+Sometimes, it could be useful to prevent the creation of snapshots, for instance in a CI environment. To do this,
+you can use the `--preventSnapshotsCreation` flag. An error will be thrown if the snapshot is missing and this option is present. 
+
 #### API Snapshot testing
 
 In order to check an api response against a snapshot, you have the following gherkin expression available:
@@ -720,7 +723,7 @@ Given:
   - /^(?:I )?do not follow redirect$/
   - /^(?:I )?follow redirect$/
   - /^(?:I )?assign request headers$/
-  - /^(?:I )?set ([a-zA-Z0-9-]+) request header to (.+)$/
+  - /^(?:I )?set ([a-zA-Z0-9-_]+) request header to (.+)$/
   - /^(?:I )?clear request headers/
   - /^(?:I )?set request json body$/
   - /^(?:I )?set request json body from (.+)$/

--- a/doc/README.tpl.md
+++ b/doc/README.tpl.md
@@ -468,6 +468,9 @@ In case you need to remove unused snapshots, you can use the option `--cleanSnap
 :warning: You shouldn't use this option with tags. It may result in used snapshots removed.
 :information_source: Snapshot files related to feature files with no snapshots anymore won't get removed. You need to do it manually.
 
+Sometimes, it could be useful to prevent the creation of snapshots, for instance in a CI environment. To do this,
+you can use the `--preventSnapshotsCreation` flag. An error will be thrown if the snapshot is missing and this option is present. 
+
 #### API Snapshot testing
 
 In order to check an api response against a snapshot, you have the following gherkin expression available:

--- a/src/extensions/snapshot/cmdOptions.js
+++ b/src/extensions/snapshot/cmdOptions.js
@@ -1,27 +1,37 @@
 'use strict'
 
-const _ = require('lodash')
+const { hasArg, hasOneArgOf } = require('../../utils/commandLine')
 
 /**
  * @module extensions/snapshot/cmdOptions
  */
 
 /**
- * Read command line option. If there is --cleanSnapshots, than we should clean snapshots
+ * Read command line option. If there is --cleanSnapshots, then we should clean snapshots
  * @type {boolean}
  */
 exports.cleanSnapshots = false
 
 /**
- * Read command line option. If there is --updateSnapshots or -u, than we should update snapshots
+ * Read command line option. If there is --updateSnapshots or -u, then we should update snapshots
  * @type {boolean}
  */
 exports.updateSnapshots = false
 
-if (!_.isEmpty(_.intersection(process.argv, ['--updateSnapshots', '-u']))) {
+/**
+ * Read command line option. If there is --preventSnapshotsCreation, then we should not create missing snapshots
+ * @type {boolean}
+ */
+exports.preventSnapshotsCreation = false
+
+if (hasOneArgOf(['--updateSnapshots', '-u'])) {
     exports.updateSnapshots = true
 }
 
-if (!_.isEmpty(_.intersection(process.argv, ['--cleanSnapshots']))) {
+if (hasArg('--cleanSnapshots')) {
     exports.cleanSnapshots = true
+}
+
+if (hasArg('--preventSnapshotsCreation')) {
+    exports.preventSnapshotsCreation = true
 }

--- a/src/extensions/snapshot/extension.js
+++ b/src/extensions/snapshot/extension.js
@@ -22,11 +22,13 @@ class Snapshot {
      * @param {Object} options - Options
      * @param {boolean} [options.updateSnapshots=false] - Should we update the snapshots
      * @param {boolean} [options.cleanSnapshots=false] - Should we clean the snapshot to remove unused snapshots
+     * @param {boolean} [options.preventSnapshotsCreation=false] - Should we avoid creating missing snapshots
      */
     constructor(options) {
         this.options = options || {}
         this.shouldUpdate = this.options.updateSnapshots
         this.cleanSnapshots = this.options.cleanSnapshots
+        this.preventSnapshotsCreation = this.options.preventSnapshotsCreation
 
         this.featureFile = null
         this.scenarioLine = -1
@@ -88,6 +90,9 @@ class Snapshot {
 
         const snapshotsContents = snapshot.readSnapshotFile(snapshotsFile)
         let snapshotContent = snapshotsContents[snapshotName]
+
+        if (this.preventSnapshotsCreation && !snapshotContent)
+            throw new Error("The snapshot does not exist and won't be created.")
 
         if (!snapshotContent) {
             statistics.created.push({ file: this.featureFile, name: snapshotName })

--- a/src/utils/commandLine.js
+++ b/src/utils/commandLine.js
@@ -1,0 +1,4 @@
+module.exports.hasArg = (arg) => process.argv.includes(arg)
+
+module.exports.hasOneArgOf = (args) =>
+    Array.isArray(args) ? args.some((arg) => process.argv.includes(arg)) : false

--- a/tests/extensions/snapshot/extension.test.js
+++ b/tests/extensions/snapshot/extension.test.js
@@ -37,7 +37,7 @@ beforeAll(() => {
         throw new Error(`Unexpected call to readFileSync with file ${file}`)
     })
 
-    fs.writeFileSync.mockImplementation((file) => {})
+    fs.writeFileSync.mockImplementation(() => {})
 
     fs.statSync.mockImplementation((file) => {
         if (file === fixtures.snapshotFile1) return {}
@@ -107,6 +107,17 @@ test("expectToMatch should write a snapshot if it doesn't exists", () => {
         fixtures.snapshotFileContent1And2
     )
     expect(fs.writeFileSync.mock.calls.length).toBe(1)
+})
+
+test('expectToMatch should not write a snapshot and throw a diff error when preventSnapshotsCreation is true', () => {
+    const snapshot = Snapshot({ preventSnapshotsCreation: true })
+    snapshot.featureFile = fixtures.featureFile1
+    snapshot.scenarioLine = 6
+
+    expect(() => snapshot.expectToMatch(fixtures.value2)).toThrow(
+        "The snapshot does not exist and won't be created."
+    )
+    expect(fs.writeFileSync).not.toHaveBeenCalled()
 })
 
 test("expectToMatch should write a snapshot file if it doesn't exists", () => {
@@ -253,7 +264,7 @@ test('expectToMatchJson should throw an error if a property matcher changes', ()
     )
 })
 
-test('expectToMatch should handle multline content correctly', () => {
+test('expectToMatch should handle multiline content correctly', () => {
     const snapshot = Snapshot({ cleanSnapshots: true })
 
     snapshot.featureFile = fixtures.featureFileMultilineString

--- a/tests/utils/commandLine.test.js
+++ b/tests/utils/commandLine.test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const sinon = require('sinon')
+
+const { hasArg, hasOneArgOf } = require('../../src/utils/commandLine')
+
+const argvStub = sinon.stub(process, 'argv')
+
+beforeAll(() => {
+    argvStub.value(['--argOne', '-t', '--three'])
+})
+
+afterEach(() => {
+    argvStub.resetHistory()
+})
+
+afterAll(() => {
+    argvStub.restore()
+})
+
+test('hasArg should return true when the arg is found', () => {
+    expect(hasArg('-t')).toBe(true)
+})
+
+test('hasArg should return false when the arg is not found', () => {
+    expect(hasArg('--missing')).toBe(false)
+})
+
+test('hasOneArgOf should return true when at least an arg is found', () => {
+    expect(hasOneArgOf(['--argOne', '--notFound'])).toBe(true)
+})
+
+test('hasOneArgOf should return false when no args are found', () => {
+    expect(hasOneArgOf(['--missing', '--notFound'])).toBe(false)
+})


### PR DESCRIPTION
Hi 👋 

This is a proposal for #59.

It adds a `--preventSnapshotsCreation` flag which prevents the creation of a missing snapshot by throwing a dedicated error.

I'll be glad to test another approach if this one isn't satisfying enough.