### PR TITLE
feat(httpApi): allow concise matcher expressions

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,5 +1,5 @@
 parserOptions:
-  ecmaVersion: 2017
+  ecmaVersion: 2019
   sourceType: script
 env:
   node: true

--- a/README.md
+++ b/README.md
@@ -237,6 +237,17 @@ Scenario: Fetching some json response from the internets
       | address.country | equal   | Japan |
 ``` 
 
+Checking json response properties start with value:
+ 
+```gherkin
+Scenario: Fetching some json response from the internets
+    When I GET http://whatever.io/things/1
+    Then json response should match
+      | field           | matcher     | value |
+      | name            | start with  | ing   |
+      | address.country | starts with | Jap   |
+``` 
+
 Checking json response properties contain value:
  
 ```gherkin
@@ -246,6 +257,17 @@ Scenario: Fetching some json response from the internets
       | field           | matcher | value |
       | name            | contain | ing   |
       | address.country | contain | Jap   |
+``` 
+
+Checking json response properties end with value:
+
+```gherkin
+Scenario: Fetching some json response from the internets
+    When I GET http://whatever.io/things/1
+    Then json response should match
+      | field           | matcher   | value |
+      | name            | end with  | ing   |
+      | address.country | ends with | pan   |
 ``` 
 
 Checking json response properties match value:
@@ -286,20 +308,51 @@ Now if the json contains extra properties, the test will fail.
 
 Available matchers are:
 
-| matcher                   | description                                       |
-|-------------------------- |---------------------------------------------------|
-| `match`                   | property must match given regexp                  |
-| `matches`                 | see `match`                                       |
-| `contain`                 | property must contain given value                 |
-| `contains`                | see `contain`                                     |
-| `defined`                 | property must not be `undefined`                  |
-| `present`                 | see `defined`                                     |
-| `equal`                   | property must equal given value                   |
-| `equals`                  | see `equal`                                       |
-| `type`                    | property must be of the given type                |
-| `equalRelativeDate`       | property must be equal to the computed date       |
+| matcher                   | short matcher             | description                                       |
+|-------------------------- |-------------------------- |---------------------------------------------------|
+| `match`                   | `~=`                      | property must match given regexp                  |
+| `matches`                 | see `match`               | see `match`                                       |
+| `start with`              | `^=`                      | property must start with given value              |
+| `starts with`             | see `start with`          | see `startWith`                                   |
+| `contain`                 | `*=`                      | property must contain given value                 |
+| `contains`                | see `contain`             | see `contain`                                     |
+| `end with`                | `$=`                      | property must end with given value                |
+| `ends with`               | see `end with`            | see `endWith`                                     |
+| `defined`                 | `?`                       | property must not be `undefined`                  |
+| `present`                 | see `defined`             | see `defined`                                     |
+| `equal`                   | `=`                       | property must equal given value                   |
+| `equals`                  | see `equal`               | see `equal`                                       |
+| `type`                    | `#=`                      | property must be of the given type                |
+| `equalRelativeDate`       | n/a                       | property must be equal to the computed date       |
 
 **Any** of these matchers can be negated when preceded by these : `!`, `not`, `does not`, `doesn't`, `is not` and `isn't`.
+
+The short version of each matcher is intended to be used that way:
+
+```gherkin
+Scenario: Fetching some json response from the internets
+    When I GET http://whatever.io/things/1
+    Then json response should fully match
+      | expression                   |
+      | name ~= ^(.+)ing$            |
+      | address.country = Japan      |
+      | address.city ?               |
+      | address.postalCode #= string |
+```
+
+If it eases the reading, you can also pad your expressions:
+
+```gherkin
+Scenario: Fetching some json response from the internets
+    When I GET http://whatever.io/things/1
+    Then json response should fully match
+      | expression                      |
+      | name               ~= ^(.+)ing$ |
+      | address.country    =      Japan |
+      | address.city       ?            |
+      | address.postalCode #=    string |
+```
+
 #### Testing response headers
 
 In order to check response headers, you have the following gherkin expression available:

--- a/doc/README.tpl.md
+++ b/doc/README.tpl.md
@@ -241,6 +241,17 @@ Scenario: Fetching some json response from the internets
       | address.country | equal   | Japan |
 ``` 
 
+Checking json response properties start with value:
+ 
+```gherkin
+Scenario: Fetching some json response from the internets
+    When I GET http://whatever.io/things/1
+    Then json response should match
+      | field           | matcher     | value |
+      | name            | start with  | ing   |
+      | address.country | starts with | Jap   |
+``` 
+
 Checking json response properties contain value:
  
 ```gherkin
@@ -250,6 +261,17 @@ Scenario: Fetching some json response from the internets
       | field           | matcher | value |
       | name            | contain | ing   |
       | address.country | contain | Jap   |
+``` 
+
+Checking json response properties end with value:
+
+```gherkin
+Scenario: Fetching some json response from the internets
+    When I GET http://whatever.io/things/1
+    Then json response should match
+      | field           | matcher   | value |
+      | name            | end with  | ing   |
+      | address.country | ends with | pan   |
 ``` 
 
 Checking json response properties match value:
@@ -290,20 +312,51 @@ Now if the json contains extra properties, the test will fail.
 
 Available matchers are:
 
-| matcher                   | description                                       |
-|-------------------------- |---------------------------------------------------|
-| `match`                   | property must match given regexp                  |
-| `matches`                 | see `match`                                       |
-| `contain`                 | property must contain given value                 |
-| `contains`                | see `contain`                                     |
-| `defined`                 | property must not be `undefined`                  |
-| `present`                 | see `defined`                                     |
-| `equal`                   | property must equal given value                   |
-| `equals`                  | see `equal`                                       |
-| `type`                    | property must be of the given type                |
-| `equalRelativeDate`       | property must be equal to the computed date       |
+| matcher                   | short matcher             | description                                       |
+|-------------------------- |-------------------------- |---------------------------------------------------|
+| `match`                   | `~=`                      | property must match given regexp                  |
+| `matches`                 | see `match`               | see `match`                                       |
+| `start with`              | `^=`                      | property must start with given value              |
+| `starts with`             | see `start with`          | see `startWith`                                   |
+| `contain`                 | `*=`                      | property must contain given value                 |
+| `contains`                | see `contain`             | see `contain`                                     |
+| `end with`                | `$=`                      | property must end with given value                |
+| `ends with`               | see `end with`            | see `endWith`                                     |
+| `defined`                 | `?`                       | property must not be `undefined`                  |
+| `present`                 | see `defined`             | see `defined`                                     |
+| `equal`                   | `=`                       | property must equal given value                   |
+| `equals`                  | see `equal`               | see `equal`                                       |
+| `type`                    | `#=`                      | property must be of the given type                |
+| `equalRelativeDate`       | n/a                       | property must be equal to the computed date       |
 
 **Any** of these matchers can be negated when preceded by these : `!`, `not`, `does not`, `doesn't`, `is not` and `isn't`.
+
+The short version of each matcher is intended to be used that way:
+
+```gherkin
+Scenario: Fetching some json response from the internets
+    When I GET http://whatever.io/things/1
+    Then json response should fully match
+      | expression                   |
+      | name ~= ^(.+)ing$            |
+      | address.country = Japan      |
+      | address.city ?               |
+      | address.postalCode #= string |
+```
+
+If it eases the reading, you can also pad your expressions:
+
+```gherkin
+Scenario: Fetching some json response from the internets
+    When I GET http://whatever.io/things/1
+    Then json response should fully match
+      | expression                      |
+      | name               ~= ^(.+)ing$ |
+      | address.country    =      Japan |
+      | address.city       ?            |
+      | address.postalCode #=    string |
+```
+
 #### Testing response headers
 
 In order to check response headers, you have the following gherkin expression available:

--- a/src/core/custom_chai_assertions.js
+++ b/src/core/custom_chai_assertions.js
@@ -1,0 +1,18 @@
+exports.registerChaiAssertion = (chai, utils) => {
+    chai.Assertion.addMethod('startWith', function (expected) {
+        return this.assert(
+            typeof this._obj === 'string' && this._obj.startsWith(expected),
+            `expected #{this} to start with #{exp}`,
+            `expected #{this} not to start with #{exp}`,
+            expected
+        )
+    })
+    chai.Assertion.addMethod('endWith', function (expected) {
+        return this.assert(
+            typeof this._obj === 'string' && this._obj.endsWith(expected),
+            `expected #{this} to end with #{exp}`,
+            `expected #{this} not to end with #{exp}`,
+            expected
+        )
+    })
+}

--- a/src/extensions/http_api/definitions.js
+++ b/src/extensions/http_api/definitions.js
@@ -9,6 +9,7 @@ const Cast = require('../../core/cast')
 const { assertObjectMatchSpec } = require('../../core/assertions')
 
 const { STATUS_CODES } = require('http')
+const { parseMatchExpression } = require('./utils')
 const STATUS_MESSAGES = _.values(STATUS_CODES).map(_.lowerCase)
 
 /**
@@ -302,13 +303,16 @@ exports.install = ({ baseUrl = '' } = {}) => {
         expect(response.headers['content-type']).to.contain('application/json')
 
         // First we populate spec values if it contains some placeholder
-        const spec = table.hashes().map((fieldSpec) =>
-            _.assign({}, fieldSpec, {
-                value: this.state.populate(fieldSpec.value),
+        const specifications = table.hashes().map((fieldSpec) => {
+            const spec = fieldSpec.expression
+                ? parseMatchExpression(fieldSpec.expression)
+                : fieldSpec
+            return _.assign({}, spec, {
+                value: this.state.populate(spec.value),
             })
-        )
+        })
 
-        assertObjectMatchSpec(body, spec, !!fully)
+        assertObjectMatchSpec(body, specifications, !!fully)
     })
 
     /**

--- a/src/extensions/http_api/utils.js
+++ b/src/extensions/http_api/utils.js
@@ -1,0 +1,7 @@
+const expressionRegex = /(?<field>[^\s]+)\s+(?<matcher>!?(?:[#~*^$]?=|\?))(?:\s+(?<value>.+))?/
+
+exports.parseMatchExpression = (expression) => {
+    const results = expressionRegex.exec(expression)
+    if (results) return results.groups
+    throw new TypeError(`'${expression}' is not a valid expression`)
+}

--- a/tests/core/custom_chai_assertions.test.js
+++ b/tests/core/custom_chai_assertions.test.js
@@ -1,0 +1,54 @@
+const chai = require('chai')
+const sinon = require('sinon')
+const { registerChaiAssertion } = require('../../src/core/custom_chai_assertions')
+
+beforeAll(() => {
+    chai.use(registerChaiAssertion)
+})
+
+test('registerChaiAssertion should add startWith and endWith assertion methods', () => {
+    const addMethodSpy = sinon.spy()
+    const fakeChai = {
+        Assertion: {
+            addMethod: addMethodSpy,
+        },
+    }
+
+    registerChaiAssertion(fakeChai, undefined)
+
+    expect(addMethodSpy.calledTwice).toBeTruthy()
+    expect(addMethodSpy.calledWith('startWith', sinon.match.func)).toBeTruthy()
+    expect(addMethodSpy.calledWith('endWith', sinon.match.func)).toBeTruthy()
+})
+
+test('chai startWith should pass', () => {
+    expect(() => chai.expect('foo').to.startWith('fo')).not.toThrow()
+})
+
+test('chai startWith should fail', () => {
+    expect(() => chai.expect('foo').to.startWith('ba')).toThrowError(
+        "expected 'foo' to start with 'ba'"
+    )
+})
+
+test('chai startWith should fail with a negated message', () => {
+    expect(() => chai.expect('foo').not.to.startWith('fo')).toThrowError(
+        "expected 'foo' not to start with 'fo'"
+    )
+})
+
+test('chai endWith should pass', () => {
+    expect(() => chai.expect('foo').to.endWith('oo')).not.toThrow()
+})
+
+test('chai endWith should fail', () => {
+    expect(() => chai.expect('foo').to.endWith('ar')).toThrowError(
+        "expected 'foo' to end with 'ar'"
+    )
+})
+
+test('chai endWith should fail with a negated message', () => {
+    expect(() => chai.expect('foo').not.to.endWith('oo')).toThrowError(
+        "expected 'foo' not to end with 'oo'"
+    )
+})

--- a/tests/extensions/http_api/utils.test.js
+++ b/tests/extensions/http_api/utils.test.js
@@ -1,0 +1,25 @@
+const { parseMatchExpression } = require('../../../src/extensions/http_api/utils')
+
+test('parseMatchExpression should throw when expression is undefined', () => {
+    expect(() => parseMatchExpression()).toThrow("'undefined' is not a valid expression")
+})
+
+test('parseMatchExpression should throw when expression does not match', () => {
+    expect(() => parseMatchExpression('does not match')).toThrow(
+        "'does not match' is not a valid expression"
+    )
+})
+
+test('parseMatchExpression should return expected groups field, matcher, and value', () => {
+    const expression = 'foo.bar[0] ~= ^(s+)$'
+
+    const expectedResult = {
+        field: 'foo.bar[0]',
+        matcher: '~=',
+        value: '^(s+)$',
+    }
+
+    const result = parseMatchExpression(expression)
+
+    expect(result).toEqual(expectedResult)
+})


### PR DESCRIPTION
Hi 👋 

/closes #16 

This PR adds support for the concise matchers as described in the related issue.
I also included two other matchers to propose a wider usage of those expressions:

- `?`: is the field defined/present?
- `#= <type>`: does the field match the `<type>`?

I also provided missing support for non-existing standard matchers "start with" and "end with".

By the way, I upgraded the ECMAScript target for ESlint to `ES2018`. This allowed me to use the RegEx named group feature and since we no longer support Node prior to version 12 this is [safe](https://node.green/#ES2018).

Let me know if you're good with this implementation 🙌 