### PR TITLE
feat(cliWrapper): wrap the cucumber CLI to keep the use of custom opt…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ jspm_packages
 .DS_Store
 .idea
 *.iml
-bin
+bin/*
 _doc
 /examples/features/file_system/files/generated
 /examples/features/file_system/files/deeply
@@ -50,3 +50,5 @@ _doc
 !.yarn/sdks
 !.yarn/versions
 .pnp.*
+
+!bin/veggies.js

--- a/bin/veggies.js
+++ b/bin/veggies.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../src/cli')

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "https://github.com/ekino/veggies.git"
   },
   "main": "src/index.js",
+  "bin": "./bin/veggies.js",
   "author": "plouc <https://github.com/plouc>",
   "maintainers": [
     {
@@ -38,7 +39,8 @@
     "natural-compare": "1.4",
     "pretty-format": "27.0",
     "request": "2.88",
-    "tough-cookie": "4.0"
+    "tough-cookie": "4.0",
+    "yargs": "17.1.1"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "12.x",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const yargs = require('yargs')
+const CucumberCli = require('@cucumber/cucumber/lib/cli').default
+
+const veggiesArguments = ['cleanSnapshots', 'preventSnapshotsCreation', 'u', 'updateSnapshots']
+
+const getValue = (value) => {
+    switch (typeof value) {
+        case 'string':
+            return ` "${value}"`
+        case 'number':
+        case 'bigint':
+            return ` ${value.toString(10)}`
+        default:
+            return undefined
+    }
+}
+
+const getCucumberArgs = (argv) => {
+    const { args, $0: cliName, _: nonPrefixedArgs, ...cliArgs } = argv
+
+    return Object.entries(cliArgs).reduce(
+        (allArgs, [arg, value]) => {
+            if (!veggiesArguments.includes(arg)) {
+                const argument = `-${arg.length > 1 ? '-' : ''}${arg}`
+                if (Array.isArray(value)) {
+                    value.forEach((it) => {
+                        allArgs.push(argument, getValue(it))
+                    })
+                } else {
+                    allArgs.push(argument)
+                    const preparedValue = getValue(value)
+                    if (preparedValue) allArgs.push(preparedValue)
+                }
+            }
+            return allArgs
+        },
+        [process.argv[0], cliName, ...nonPrefixedArgs]
+    )
+}
+
+yargs
+    .scriptName('veggies')
+    .usage('$0 [cucumber-args]')
+    .command('$0 [args]', "Run 'cucumber-cli' after having removed custom options", async function (
+        argv
+    ) {
+        const cucumberArgs = getCucumberArgs(argv.argv)
+
+        await new CucumberCli({
+            argv: cucumberArgs,
+            cwd: process.cwd(),
+            stdout: process.stdout,
+        }).run()
+    })
+    .help().argv

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,8 +963,11 @@ __metadata:
     request: 2.88
     sinon: 11.x
     tough-cookie: 4.0
+    yargs: 17.1.1
   peerDependencies:
     "@cucumber/cucumber": ">=7.0.0"
+  bin:
+    veggies: ./bin/veggies.js
   languageName: unknown
   linkType: soft
 
@@ -7908,6 +7911,21 @@ fsevents@^2.3.2:
   version: 20.2.9
   resolution: "yargs-parser@npm:20.2.9"
   checksum: 3c58da6f6142f93c5207e309764bd90f723b9d7ed43f2e8aad0da1cefab83ee8ebf311dee2e81102646b74450c899e35b35053800b91fac23e6f433056f4c4cf
+  languageName: node
+  linkType: hard
+
+"yargs@npm:17.1.1":
+  version: 17.1.1
+  resolution: "yargs@npm:17.1.1"
+  dependencies:
+    cliui: ^7.0.2
+    escalade: ^3.1.1
+    get-caller-file: ^2.0.5
+    require-directory: ^2.1.1
+    string-width: ^4.2.0
+    y18n: ^5.0.5
+    yargs-parser: ^20.2.2
+  checksum: c2a16b61eb0db8882becd0aa382a5c59b87afcd17b35dd7077b3c9d83f77a3ad3de1526e4f1cf940f9481d7ce537e883af7c16879c33258724a09bc43a04e8ea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is an attempt to maintain our custom CLI options while preventing the `@cucumbere/cucumber` CLI to reject our custom options.

⚠️ This is a work in progress. I want your feeling about this before going further. ⚠️ 

It uses `yargs` to parse the `process.argv` then removes any options that veggies has use of (I think it's better to be loose here in the event of a new cucumber CLI option added).

It rebuild an array of command-line arguments as it could have been passed on the original command before programmatically launching the CLI with those options.

This should launch the CLI without any issue:
```shell
$ yarn veggies examples/**/*.feature --cleanSnapshots
UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU

Failures:

1) Scenario: Running an invalid command # examples/features/cli/yarn.feature:4
   ? When I run command node -z
[...]
```

An unknown option is passed to the cucumber CLI:
```shell
$ yarn veggies examples/**/*.feature --cleanSnapshots --foo
error: unknown option '--foo'
```