### PR TITLE
fix(snapshot): remove usage of private variable from jest-diff

### DIFF
--- a/src/extensions/snapshot/snapshot.js
+++ b/src/extensions/snapshot/snapshot.js
@@ -7,7 +7,6 @@
 const _ = require('lodash')
 const path = require('path')
 const { diff } = require('jest-diff')
-const jestDiffConstants = require('jest-diff/build/constants')
 const naturalCompare = require('natural-compare')
 const chalk = require('chalk')
 
@@ -15,6 +14,7 @@ const fileSystem = require('./fs')
 
 const EXPECTED_COLOR = chalk.green
 const RECEIVED_COLOR = chalk.red
+const JEST_NO_DIFF_MESSAGE = 'Compared values have no visual difference.'
 
 exports.scenarioRegex = /^[\s]*Scenario:[\s]*(.*[^\s])[\s]*$/
 
@@ -148,7 +148,7 @@ exports.diff = (snapshot, expected) => {
     diffMessage =
         diffMessage ||
         `${EXPECTED_COLOR('- ' + (expected || ''))} \n ${RECEIVED_COLOR('+ ' + snapshot)}`
-    if (diffMessage.indexOf(jestDiffConstants.NO_DIFF_MESSAGE) !== -1) return null
+    if (diffMessage.indexOf(JEST_NO_DIFF_MESSAGE) !== -1) return null
     return `\n${diffMessage}`
 }
 

--- a/tests/extensions/snapshot/snapshot.test.js
+++ b/tests/extensions/snapshot/snapshot.test.js
@@ -5,7 +5,6 @@ const fileSystem = require('../../../src/extensions/snapshot/fs')
 const dedent = require('../../../src/extensions/snapshot/dedent')
 
 const { diff } = require('jest-diff')
-const diffConstants = require('jest-diff/build/constants')
 
 jest.mock('jest-diff', () => ({ diff: jest.fn() }))
 
@@ -122,7 +121,7 @@ describe('diff', () => {
              has
              nothing to do with the 
              result!
-             -> ${diffConstants.NO_DIFF_MESSAGE} ¯\\_(ツ)_/¯
+             -> Compared values have no visual difference. ¯\\_(ツ)_/¯
          `
 
         diff.mockReturnValue(diffResult)


### PR DESCRIPTION
Hi 👋 

While testing the new version of Veggies, I saw an error regarding access to a non-exported object.

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './build/constants' is not defined by "exports" in /usr/src/app/node_modules/@ekino/veggies/node_modules/jest-diff/package.json
    at throwExportsNotFound (internal/modules/esm/resolve.js:299:9)
    at packageExportsResolve (internal/modules/esm/resolve.js:522:3)
    at resolveExports (internal/modules/cjs/loader.js:449:36)
    at Function.Module._findPath (internal/modules/cjs/loader.js:489:31)
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:875:27)
    at Function.Module._load (internal/modules/cjs/loader.js:745:27)
    at Module.require (internal/modules/cjs/loader.js:961:19)
    at require (internal/modules/cjs/helpers.js:92:18)
    at Object.<anonymous> (/usr/src/app/node_modules/@ekino/veggies/src/extensions/snapshot/snapshot.js:10:27)
    at Module._compile (internal/modules/cjs/loader.js:1072:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
    at Module.load (internal/modules/cjs/loader.js:937:32)
    at Function.Module._load (internal/modules/cjs/loader.js:778:12)
    at Module.require (internal/modules/cjs/loader.js:961:19)
    at require (internal/modules/cjs/helpers.js:92:18)
    at Object.<anonymous> (/usr/src/app/node_modules/@ekino/veggies/src/extensions/snapshot/clean.js:9:18)
codepath: /usr/src/app/tests/functional/support/hooks.js
```

This is related to this PR: facebook/jest#9921.

I'm not sure why this error did not show up on our tests 🤷 