### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.0 (2021-11-26)
+
+* chore: changelog script should not override previous versions ([8012b47](https://github.com/ekino/veggies/commit/8012b47))
+* chore(yarn): update Yarn version ([c3dba4c](https://github.com/ekino/veggies/commit/c3dba4c))
+* feat(cucumber): explicit import of the index file for the CLI ([b3ad0e6](https://github.com/ekino/veggies/commit/b3ad0e6))
+
+
+
 ## 1.0.1 (2021-09-16)
 
 * feat(cliWrapper): wrap the cucumber CLI to keep the use of custom options ([e0fa4f9](https://github.com/ekino/veggies/commit/e0fa4f9))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ekino/veggies",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Veggies is an awesome cucumberjs library for API/CLI testing. Great for testing APIs built upon Express, Koa, HAPI, Loopback and others. It's also the perfect companion for testing CLI applications built with commander, meow & Co.",
   "tags": [
     "bdd",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,6 @@
     "doc": "jsdoc -c .jsdoc.json --verbose",
     "doc-pub": "yarn run readme && yarn run doc && gh-pages -d _doc",
     "examples": "veggies --require examples/support examples/features",
-    "changelog": "conventional-changelog -p conventionalcommits -i CHANGELOG.md -s -r 0"
+    "changelog": "conventional-changelog -p conventionalcommits -i CHANGELOG.md -s"
   }
 }


### PR DESCRIPTION
Also fixes the `changelog` script which was overriding the previous changelog each time 😬  (on a dedicated commit)