### PR TITLE
feat(httpApi): add definition to replace placeholder in key of state

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,15 @@ Scenario Outline: Fetching <key> API endpoint from root endpoint
     | public_gists_url |
 ```
 
-You can also pick a field from response headers.
+
+Pick a value from response header
+
+Syntax:
+```
+I pick response header <key> as <key>
+```
+
+Example:
 
 ```gherkin
 Scenario: Setting json body from .json fixture file
@@ -238,6 +246,23 @@ Scenario: Setting json body from .json fixture file
     And I clear request body
     And I GET {{location}}
     And response status code should be 200
+```
+
+
+
+#### Replace placeholder in key of state:
+
+Syntax:
+```
+I replace (placeholder) <search> in <key> to <value> with regex option <flags>
+```
+- `placeholder` and `with regex option <flags>` are optional
+- `<value>` does not support spaces
+
+Example: 
+```
+And I replace {token} in URLPage to e1c401d5c
+And I replace placeholder {stateUpMode} in URLPage to live with regex option gi
 ```
 
 #### Using cookies
@@ -827,6 +852,7 @@ Given:
   - /^(?:I )?clear request body$/
   - /^(?:I )?set request query$/
   - /^(?:I )?pick response (json|header) (.+) as (.+)$/
+  - /^(?:I )?replace(?: placeholder)? (.+) in (.+) to ([^\s]+)(?: with regex options? (.+)?)?$/
   - /^(?:I )?enable cookies$/
   - /^(?:I )?disable cookies$/
   - /^(?:I )?set cookie from (.+)$/

--- a/doc/README.tpl.md
+++ b/doc/README.tpl.md
@@ -231,7 +231,15 @@ Scenario Outline: Fetching <key> API endpoint from root endpoint
 ```
 <%={{ }}=%>
 
-You can also pick a field from response headers.
+
+Pick a value from response header
+
+Syntax:
+```
+I pick response header <key> as <key>
+```
+
+Example:
 
 {{=<% %>=}}
 ```gherkin
@@ -245,6 +253,23 @@ Scenario: Setting json body from .json fixture file
     And response status code should be 200
 ```
 <%={{ }}=%>
+
+
+
+#### Replace placeholder in key of state:
+
+Syntax:
+```
+I replace (placeholder) <search> in <key> to <value> with regex option <flags>
+```
+- `placeholder` and `with regex option <flags>` are optional
+- `<value>` does not support spaces
+
+Example: 
+```
+And I replace {token} in URLPage to e1c401d5c
+And I replace placeholder {stateUpMode} in URLPage to live with regex option gi
+```
 
 #### Using cookies
 

--- a/src/extensions/http_api/definitions.js
+++ b/src/extensions/http_api/definitions.js
@@ -136,6 +136,19 @@ exports.install = ({ baseUrl = '' } = {}) => {
     })
 
     /**
+     * Pick a value from previous json response or header and set it to state
+     */
+    Given(
+        /^(?:I )?replace(?: placeholder)? (.+) in (.+) to ([^\s]+)(?: with regex options? (.+)?)?$/,
+        function (search, key, replaceValue, option) {
+            let newValue = this.state
+                .get(key)
+                .replace(new RegExp(search, option || undefined), replaceValue)
+            this.state.set(key, newValue)
+        }
+    )
+
+    /**
      * Enabling cookies
      */
     Given(/^(?:I )?enable cookies$/, function () {

--- a/tests/extensions/http_api/definitions.test.js
+++ b/tests/extensions/http_api/definitions.test.js
@@ -275,6 +275,46 @@ test('pick response json|header property', () => {
     def.shouldMatch('pick response header key as value', ['header', 'key', 'value'])
 })
 
+test('replace value of state key', () => {
+    const context = helper.getContext() // Extension context
+
+    const def = context.getDefinitionByMatcher(
+        'replace(?: placeholder)? (.+) in (.+) to ([^\\s]+)(?: with regex options? (.+)?)?'
+    )
+    def.shouldNotMatch('replace key {token} in URLPage to')
+    def.shouldNotMatch('I replace {token} in URLPage to   ')
+    def.shouldMatch('replace {token} in URLPage to abcd', ['{token}', 'URLPage', 'abcd'])
+    def.shouldMatch('I replace placeholder {token} in URLPage to abcd', [
+        '{token}',
+        'URLPage',
+        'abcd',
+    ])
+    def.shouldMatch('I replace placeholder {token} in URLPage to abcd with regex option gi', [
+        '{token}',
+        'URLPage',
+        'abcd',
+        'gi',
+    ])
+    def.shouldMatch('I replace {token} in URLPage to abcd with regex options gi', [
+        '{token}',
+        'URLPage',
+        'abcd',
+        'gi',
+    ])
+    const URLPage = 'http://localhost:300/api/{token}/page'
+    const newURLPage = 'http://localhost:300/api/abcd/page'
+    const stateMock = {
+        state: {
+            get: jest.fn().mockImplementation(() => URLPage),
+            set: jest.fn().mockImplementation(() => newURLPage),
+        },
+    }
+
+    def.exec(stateMock, '{token}', 'URLPage', 'abcd', 'gi')
+    expect(stateMock.state.get).toHaveBeenCalledWith('URLPage')
+    expect(stateMock.state.set).toHaveBeenCalledWith('URLPage', newURLPage)
+})
+
 test('enable cookies', () => {
     const context = helper.getContext() // Extension context
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
The two fields below are mandatory.
-->

**Summary**
Add a definition to replace the placeholder in key of state.

I think Il will be helpful for e2e testing e2e with templating url.

Definition: `replace <search> in <key> to <value> with regex option <flags>`

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

