### PR TITLE
Fix output matcher snapshot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,16 +44,13 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
-      - name: Verify version bump
-        run: |
-          echo "Version bumped to $(node -p "require('./package.json').version")"
-
       - name: Bump version
         id: versioning
         run: |
           npm version ${{ github.event.inputs.strategy }} -m "chore(release): v%s"
           VERSION=$(node -p "require('./package.json').version")
           echo "current-version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version bumped to $VERSION"
 
       - name: Set up git-cliff
         uses: kenji-miyake/setup-git-cliff@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
 permissions:
   contents: write
 
+run-name: Release v${{ inputs.strategy }}
+
 jobs:
   release:
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -1131,8 +1131,8 @@ Due to public API rate limit (e.g. GitHub API), this tag is used when running on
 
 [npm-image]: https://img.shields.io/npm/v/@ekino/veggies.svg?longCache=true&style=for-the-badge
 [npm-url]: https://www.npmjs.com/package/@ekino/veggies
-[ci-image]: https://img.shields.io/github/workflow/status/ekino/veggies/Node.js%20CI?style=for-the-badge
-[ci-url]: https://github.com/ekino/veggies/actions
+[ci-image]: https://img.shields.io/github/actions/workflow/status/ekino/veggies/release.yml?branch=master&style=for-the-badge
+[ci-url]: https://github.com/ekino/veggies/actions/workflows/release.yml
 [coverage-image]: https://img.shields.io/coveralls/ekino/veggies/master.svg?longCache=true&style=for-the-badge
 [coverage-url]: https://coveralls.io/github/ekino/veggies?branch=master
 [github-watch-badge]: https://img.shields.io/github/watchers/ekino/veggies.svg?style=social

--- a/src/extensions/snapshot/extension.ts
+++ b/src/extensions/snapshot/extension.ts
@@ -45,7 +45,10 @@ class Snapshot {
 
         const copy = structuredClone(expectedContent)
         for (const { field, matcher, value } of spec) {
-            if (field) setValue(copy, field, `${matcher}(${value})`)
+            if (field) {
+                const snapshotValue = value === undefined ? '' : value
+                setValue(copy, field, `${matcher}(${snapshotValue})`)
+            }
         }
 
         this.expectToMatch(copy)

--- a/tests/functional/features/snapshot/__snapshots__/snapshot.feature.snap
+++ b/tests/functional/features/snapshot/__snapshots__/snapshot.feature.snap
@@ -1,12 +1,13 @@
 
 
 exports[`Snapshot testing on a cli with json output 1.1`] = `Object {
+  "first_name": "defined()",
   "gender": "equal(male)",
   "name": "john",
 }`;
 
 exports[`Snapshot testing on a json api 1.1`] = `Object {
-  "first_name": "Raphaël",
+  "first_name": "defined()",
   "gender": "type(string)",
   "id": 1,
   "last_name": "Benitte",

--- a/tests/functional/features/snapshot/snapshot.feature
+++ b/tests/functional/features/snapshot/snapshot.feature
@@ -23,13 +23,15 @@ Feature: Using snapshot definitions
         Then response json body should match snapshot
             | field           | matcher | value    |
             | gender          | type    | string   |
+            | first_name      | defined |          |
 
     Scenario: Snapshot testing on a cli with json output
-        When I run command echo {"gender": "male", "name": "john"}
+        When I run command echo {"gender": "male", "name": "john", "first_name": "Lily"}
         Then exit code should be 0
         And stdout json output should match snapshot
             | field           | matcher | value    |
             | gender          | equal   | male     |
+            | first_name      | defined |          |
 
     Scenario: Snapshot testing on a json file
         Given I set cwd to examples/features/snapshot/fixtures


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
The two fields below are mandatory.
-->

**Summary**
Do not print undefined value to snapshot

We must keep same behavior as the 1.x version.

- Actual behavior:
```
And response json body should match snapshot 
definitions.js:16
       | field                       | matcher | value |
       | filters[0].contents | defined  |           |
 Error:
       - Snapshot
       + Received

       @@ -76,11 +76,11 @@
           "filters": Array [
             Object {
       -       "contents": "defined()",
       +       "contents": "defined(undefined)",
               "id": "day",
             },
```

- Expected behavior:
do not print the "undefined" as string in the snapshot file

