### PR TITLE
fix(http_api): use URL constructor instead of path.join to prevent malformed URLs

### DIFF
--- a/src/extensions/http_api/client.ts
+++ b/src/extensions/http_api/client.ts
@@ -1,4 +1,3 @@
-import pathModule from 'node:path'
 import axios, { type AxiosInstance, type AxiosResponse } from 'axios'
 import { wrapper } from 'axios-cookiejar-support'
 import FormData from 'form-data'
@@ -229,7 +228,7 @@ class HttpApiClient {
                 baseUrl = url.origin
             }
 
-            const fullUrl = pathModule.join(baseUrl, path)
+            const fullUrl = new URL(path, baseUrl).toString()
             const options: RequestOptions = {
                 method,
                 url: fullUrl,

--- a/tests/unit/extensions/http_api/client.test.ts
+++ b/tests/unit/extensions/http_api/client.test.ts
@@ -1,0 +1,38 @@
+import axios from 'axios'
+import { describe, expect, test, vi } from 'vitest'
+import { HttpApiClient } from '../../../../src/extensions/http_api/client.js'
+
+vi.mock('axios', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('axios')>()
+    const mockAxiosInstance = {
+        request: vi.fn().mockResolvedValue({ status: 200, data: { ok: true } }),
+        interceptors: {
+            request: { use: vi.fn() },
+            response: { use: vi.fn() },
+        },
+    }
+    return {
+        default: {
+            ...actual.default,
+            create: vi.fn(() => mockAxiosInstance),
+            isAxiosError: actual.default.isAxiosError,
+        },
+    }
+})
+
+describe('extensions > http_api > client', () => {
+    test('makeRequest handles http URLs correctly without malforming them', async () => {
+        const client = new HttpApiClient()
+
+        await client.makeRequest('GET', '/test', 'http://example.com')
+
+        const mockCreate = vi.mocked(axios.create)
+        const mockAxiosInstance = mockCreate.mock.results[0]?.value
+
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: 'http://example.com/test',
+            })
+        )
+    })
+})


### PR DESCRIPTION
**Summary**

This pull request solves a compatibility issue introduced with Axios >= 1.18 (which implements stricter URL parsing).

Currently, the HttpApiClient.makeRequest() method uses node:path's path.join(baseUrl, path) to concatenate the final URL. However, path.join is strictly meant for local filesystems and collapses the // of the HTTP protocol into a single slash (e.g., transforming http://example.com/api into http:/example.com/api).

With recent Axios versions, this results in an ERR_INVALID_URL exception that is silently caught, leaving the response undefined. To fix this, I replaced path.join with the native URL constructor, which securely handles URL composition. I also removed the now-unused node:path import.

**Test plan**

Added a new unit test in tests/unit/extensions/http_api/client.test.ts.
Mocks the axios library using vitest (vi.mock('axios')) to intercept the request and assert that the constructed url property is fully valid (e.g., http://example.com/test).
Confirmed that the test fails on the main branch with the malformed URL (http:/...) and successfully passes with the URL constructor fix.
Ensured all other unit and functional tests still pass.

Closes #107 